### PR TITLE
Adding params for earlyStopping arguments

### DIFF
--- a/R/CIReNN.R
+++ b/R/CIReNN.R
@@ -123,7 +123,7 @@ fitCIReNN <- function(plpData,population, param, search='grid', quiet=F,
   
   result<- toSparseM(plpData,population,map=NULL, temporal=T)
   data <- result$data
-
+  covariateMap <- result$map
   #remove result to save memory
   rm(result)
   
@@ -163,7 +163,7 @@ fitCIReNN <- function(plpData,population, param, search='grid', quiet=F,
                  cohortId=cohortId,
                  varImp = covariateRef, 
                  trainingTime =comp,
-                 covariateMap=result$map
+                 covariateMap=covariateMap
   )
   class(result) <- 'plpModel'
   attr(result, 'type') <- 'deep'

--- a/R/CIReNN.R
+++ b/R/CIReNN.R
@@ -97,8 +97,9 @@ setCIReNN <- function(units=c(128, 64), recurrentDropout=c(0.2), layerDropout=c(
     units=units, recurrentDropout=recurrentDropout, 
     layerDropout=layerDropout,
     lr =lr, decay=decay, outcomeWeight=outcomeWeight,epochs= epochs,
+    earlyStoppingMinDelta = earlyStoppingMinDelta, earlyStoppingPatience = earlyStoppingPatience,
     seed=ifelse(is.null(seed),'NULL', seed)),
-    1:(length(units)*length(recurrentDropout)*length(layerDropout)*length(lr)*length(decay)*length(outcomeWeight)*length(epochs)*max(1,length(seed)))),
+    1:(length(units)*length(recurrentDropout)*length(layerDropout)*length(lr)*length(decay)*length(outcomeWeight)*length(earlyStoppingMinDelta)*length(earlyStoppingPatience)*length(epochs)*max(1,length(seed)))),
     name='CIReNN'
   )
 
@@ -122,6 +123,9 @@ fitCIReNN <- function(plpData,population, param, search='grid', quiet=F,
   
   result<- toSparseM(plpData,population,map=NULL, temporal=T)
   data <- result$data
+
+  #remove result to save memory
+  #rm(result)
   
   #one-hot encoding
   population$y <- keras::to_categorical(population$outcomeCount, 2)#[,2] #population$outcomeCount

--- a/R/CIReNN.R
+++ b/R/CIReNN.R
@@ -125,7 +125,7 @@ fitCIReNN <- function(plpData,population, param, search='grid', quiet=F,
   data <- result$data
 
   #remove result to save memory
-  #rm(result)
+  rm(result)
   
   #one-hot encoding
   population$y <- keras::to_categorical(population$outcomeCount, 2)#[,2] #population$outcomeCount

--- a/man/setCIReNN.Rd
+++ b/man/setCIReNN.Rd
@@ -7,6 +7,7 @@
 setCIReNN(units = c(128, 64), recurrentDropout = c(0.2),
   layerDropout = c(0.2), lr = c(1e-04), decay = c(1e-05),
   outcomeWeight = c(1), batchSize = c(100), epochs = c(100),
+  earlyStoppingMinDelta = c(1e-4), earlyStoppingPatience = c(10),
   seed = NULL)
 }
 \arguments{
@@ -25,6 +26,10 @@ setCIReNN(units = c(128, 64), recurrentDropout = c(0.2),
 \item{batchSize}{The number of data points to use per training batch}
 
 \item{epochs}{Number of times to iterate over dataset}
+
+\item{earlyStoppingMinDelta}{minimum change in the monitored quantity to qualify as an improvement for early stopping, i.e. an absolute change of less than min_delta in loss of validation data, will count as no improvement.}
+
+\item{earlyStoppingPatience}{Number of epochs with no improvement after which training will be stopped.}
 
 \item{seed}{Random seed used by deep learning model}
 }


### PR DESCRIPTION
Hello,

To let users set arguments for early stopping in CIReNN, I added params for earlyStopping in set function.
And to save memory, I modify the fitCIReNN to remove result(sparse array for whole feature vector) among the code.