### PR TITLE
Replacement for personSplitter that splits on subjectId, not rowId.

### DIFF
--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -31,101 +31,108 @@
 #' @return
 #' A dataframe containing the columns: rowId and index
 #' @export
-personSplitter <- function(population, test = 0.3, train = NULL, nfold = 3, seed = NULL) {
+personSplitter <- function(population, test=0.3, train=NULL, nfold=3, seed=NULL) {
+    # Check logger
+    if(length(ParallelLogger::getLoggers())==0){
+        logger <- ParallelLogger::createLogger(name = "SIMPLE",
+                                            threshold = "INFO",
+                                            appenders = list(ParallelLogger::createConsoleAppender(layout = ParallelLogger::layoutTimestamp)))
+        ParallelLogger::registerLogger(logger)
+    }
+    if (!is.null(seed))
+        set.seed(seed)
 
-  # check logger
-  if(length(ParallelLogger::getLoggers())==0){
-    logger <- ParallelLogger::createLogger(name = "SIMPLE",
-                                        threshold = "INFO",
-                                        appenders = list(ParallelLogger::createConsoleAppender(layout = ParallelLogger::layoutTimestamp)))
-    ParallelLogger::registerLogger(logger)
-  }
+    if (!class(nfold) %in% c("numeric","integer") | nfold < 1) {
+        stop("nfold must be an integer 1 or greater")
+    }
 
-  # parameter checking
-  if (!is.null(seed))
-    set.seed(seed)
-
-  if (!class(nfold) %in% c("numeric","integer") | nfold < 1) {
-    stop("nfold must be an integer 1 or greater")
-  }
-
-  if (!class(test) %in% c("numeric","integer") | test <= 0 | test >= 1) {
-    stop("test must be between 0 and 1")
-  }
-  
-  if (is.null(train)) {
-    train <- 1 - test
-  }
-  
-  if (!class(train) %in% c("numeric","integer") | train <= 0 | train > 1-test) {
-    stop("train must be between 0 and 1-test")
-  }
-
-  if (length(table(population$outcomeCount)) <= 1 | sum(population$outcomeCount > 0) < 10) {
-    stop("Outcome only occurs in fewer than 10 people or only one class")
-  }
-
-  if (floor(sum(population$outcomeCount > 0) * test/nfold) == 0) {
-    stop("Insufficient outcomes for choosen nfold value, please reduce")
-  }
-  
-
-  ParallelLogger::logInfo(paste0("Creating a ",
-                   test * 100,
-                   "% test and ",
-                   train * 100,
-                   "% train (into ",
-                   nfold,
-                   " folds) stratified split by person"))
-  outPpl <- population$rowId[population$outcomeCount == 1]
-  nonPpl <- population$rowId[population$outcomeCount == 0]
-
-  # give random number to all and shuffle then assign to test/train/cv if using set.seed() then use
-  # permutation <- stats::runif(length(nonPpl)+length(outPpl)) and nonPpl <-
-  # nonPpl[order(permutation[1:length(nonPpl)])] and outPpl <-
-  # outPpl[order(permutation[(1+length(nonPpl)):length(permutation)])]
-  nonPpl <- nonPpl[order(stats::runif(length(nonPpl)))]
-  outPpl <- outPpl[order(stats::runif(length(outPpl)))]
-
-  # reset all to not included (index=0)
-  nonPpl.group <- rep(0, length(nonPpl))
-  
-  # set test set (index=-1)
-  test.ind <- 1:round(length(nonPpl) * test)
-  nonPpl.group[test.ind] <- -1
-  
-  # set train set (index>0)
-  train.ind <- round(length(nonPpl) * test + length(nonPpl) * (1-train-test) + 1):length(nonPpl) 
-  reps <- floor(length(train.ind)/nfold)
-  leftOver <- length(train.ind)%%nfold
-  if (leftOver > 0)
-    nonPpl.group[train.ind] <- c(rep(1:nfold, each = reps), 1:leftOver)
-  if (leftOver == 0)
-    nonPpl.group[train.ind] <- rep(1:nfold, each = reps)
+    if (!class(test) %in% c("numeric","integer") | test <= 0 | test >= 1) {
+        stop("test must be between 0 and 1")
+    }
     
-  # same for outcome = 1
-  outPpl.group <- rep(0, length(outPpl))
-  test.ind <- 1:round(length(outPpl) * test)
-  outPpl.group[test.ind] <- -1
-  train.ind <- round(length(outPpl) * test + length(outPpl) * (1-train-test) + 1):length(outPpl)
-  reps <- floor(length(train.ind)/nfold)
-  leftOver <- length(train.ind)%%nfold
-  if (leftOver > 0)
-    outPpl.group[train.ind] <- c(rep(1:nfold, each = reps), 1:leftOver)
-  if (leftOver == 0)
-    outPpl.group[train.ind] <- rep(1:nfold, each = reps)
+    if (is.null(train)) {
+        train <- 1 - test
+    }
+    
+    if (train + test > 1) {
+        stop('train + test must be less than 1')
+    }
+    
+    leftover <- 1 - train - test
+    
+    
+    if (length(table(population$outcomeCount)) <= 1 | sum(population$outcomeCount > 0) < 10) {
+        stop("Outcome only occurs in fewer than 10 people or only one class")
+    }
 
-  split <- data.frame(rowId = c(nonPpl, outPpl), index = c(nonPpl.group, outPpl.group))
-  split <- split[order(-split$rowId), ]
+    if (floor(sum(population$outcomeCount > 0) * test/nfold) == 0) {
+        stop("Insufficient outcomes for choosen nfold value, please reduce")
+    }
+    
+    ParallelLogger::logInfo(paste0("Creating a ",
+               test * 100,
+               "% test and ",
+               train * 100,
+               "% train (into ",
+               nfold,
+               " folds) stratified split by person"))
+    
+    # Get the unique set of subjects
+    subject_df <- population %>% select(subjectId) %>% distinct
+    
+    # Shuffle the subjects
+    subject_df <- subject_df %>% sample_n(nrow(subject_df), replace=FALSE)
+    
+    # Record the number of samples in each split
+    num_test <- floor(test*nrow(subject_df))
+    num_leftover <- floor(leftover*nrow(subject_df))
+    num_train <- nrow(subject_df) - num_test - num_leftover
+    
+    # Get the subjects in the test set
+    test_subject_df <- subject_df %>% 
+                    slice(1:num_test) %>% 
+                    mutate(index=-1)
 
-  foldSizesTrain <- utils::tail(table(split$index), nfold)
-  ParallelLogger::logInfo(paste0("Data split into ", sum(split$index < 0), " test cases and ", sum(split$index >
-    0), " train cases", " (", toString(foldSizesTrain), ")"))
-  if (test+train<1)
-    ParallelLogger::logInfo(paste0(sum(split$index == 0), " were not used for training or testing"))
-  
-  # return index vector
-  return(split)
+    # Get the subjects that are in neither train nor test
+    if (num_leftover==0) {
+        # We take a dataframe with zero rows if num_leftover==0
+        leftover_subject_df <- subject_df %>% slice(0)
+    } else {
+        leftover_subject_df <- subject_df %>% 
+        anti_join(test_subject_df) %>%
+        slice(1:num_leftover) %>% 
+        mutate(index=0)
+    }
+    
+    # Assign fold ids to the training set
+    train_subject_df <- subject_df %>% 
+        anti_join(rbind(test_subject_df, leftover_subject_df)) %>%
+        mutate(index = rep(seq.int(from = 1, to = nfold, by = 1), 
+                           times = floor(num_train / nfold), 
+                           length.out = num_train
+                          )
+              )
+    # Combine the sets into a dataframe with columns (subjectId, index)
+    subject_df <- rbind(test_subject_df, leftover_subject_df, train_subject_df)
+    
+    # Map the results to the population data frame
+    split <- population %>% inner_join(subject_df)
+    
+    # Produce a summary
+    summary_df <- split %>% 
+                    group_by(index) %>% 
+                    summarise(subject_count=length(unique(subjectId)), row_count=n())
+    
+    ParallelLogger::logInfo(paste0("Data split into ", 
+                                   select(filter(summary_df, index==-1), subject_count), " test subjects, " , 
+                                   select(filter(summary_df, index==-1), row_count), " test rows, ", 
+                                   select(filter(summary_df, index>0), subject_count), " train subjects, ", 
+                                   select(filter(summary_df, index>0), row_count), " train rows "
+                                  )
+                           )
+    
+    split <- split %>% select(rowId, index) %>% arrange(rowId)
+    return(split)
 }
 
 

--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -58,7 +58,7 @@ personSplitter <- function(population, test=0.3, train=NULL, nfold=3, seed=NULL)
         stop('train + test must be less than 1')
     }
     
-    leftover <- 1 - train - test
+    leftover <- max(c(0, 1 - train - test))
     
     
     if (length(table(population$outcomeCount)) <= 1 | sum(population$outcomeCount > 0) < 10) {
@@ -85,7 +85,7 @@ personSplitter <- function(population, test=0.3, train=NULL, nfold=3, seed=NULL)
     
     # Record the number of samples in each split
     num_test <- floor(test*nrow(subject_df))
-    num_leftover <- floor(leftover*nrow(subject_df))
+    num_leftover <- max(c(0, floor(leftover*nrow(subject_df))))
     num_train <- nrow(subject_df) - num_test - num_leftover
     
     # Get the subjects in the test set


### PR DESCRIPTION
This is a reimplementation of the personSplitter function that creates splits that are suitable to the setting where multiple predictions are made for each patient. In this setting, we would like for all of the predictions made for a particular patient to belong to only one data partition (train vs. test, or cross validation folds). As far as I can tell, the existing function always splits on rowId and thus biases both cross validation and the final evaluation on the test set.

As this is a complete reimplementation of the method, it may break reproducibility for previous studies. It may be appropriate to include this as a new function rather than a replacement.

