### PR TITLE
Add flag to only fetch data without running analyses

### DIFF
--- a/R/RunMultiplePlp.R
+++ b/R/RunMultiplePlp.R
@@ -48,6 +48,7 @@
 #' @param outcomeTable                   The tablename that contains the outcome cohorts.  Expectation is
 #'                                       outcomeTable has format of COHORT table: COHORT_DEFINITION_ID,
 #'                                       SUBJECT_ID, COHORT_START_DATE, COHORT_END_DATE.
+#' @param onlyFetchData                  Only fetches and saves the data object to the output folder without running the analysis.
 #' @param outputFolder                   Name of the folder where all the outputs will written to.
 #' @param modelAnalysisList              A list of objects of type \code{modelSettings} as created using
 #'                                       the \code{\link{createPlpModelSettings}} function.
@@ -82,6 +83,7 @@ runPlpAnalyses <- function(connectionDetails,
                           outcomeDatabaseSchema = cdmDatabaseSchema,
                           outcomeTable = "cohort",
                           cdmVersion = 5,
+                          onlyFetchData = FALSE,
                           outputFolder = "./PlpOutput",
                           modelAnalysisList,
                           cohortIds,
@@ -233,7 +235,7 @@ runPlpAnalyses <- function(connectionDetails,
     }
     
     plpResultFolder = file.path(referenceTable$plpResultFolder[i],'plpResult')
-    if(!dir.exists(plpResultFolder)){
+    if(!dir.exists(plpResultFolder) && !onlyFetchData){
       ParallelLogger::logTrace(paste0('Running runPlp for setting ', i ))
       dir.create(referenceTable$plpResultFolder[i], recursive = T)
       # runPlp and save result to referenceTable$plpResultFolder

--- a/man/runPlpAnalyses.Rd
+++ b/man/runPlpAnalyses.Rd
@@ -14,6 +14,7 @@ runPlpAnalyses(
   outcomeDatabaseSchema = cdmDatabaseSchema,
   outcomeTable = "cohort",
   cdmVersion = 5,
+  onlyFetchData = FALSE,
   outputFolder = "./PlpOutput",
   modelAnalysisList,
   cohortIds,
@@ -65,6 +66,8 @@ SUBJECT_ID, COHORT_START_DATE, COHORT_END_DATE.}
 
 \item{cdmVersion}{Define the OMOP CDM version used: currently support "4" and
 "5".}
+
+\item{onlyFetchData}{Only fetches and saves the data object to the output folder without running the analysis.}
 
 \item{outputFolder}{Name of the folder where all the outputs will written to.}
 


### PR DESCRIPTION
Hi,

can we add a flag to only fetch plpData when using a prediction package without running the analyses? Currently `runPlpAnalyses()` always does both at the same time ;-)

Use case 1: Allows us to split up larger studies into "data fetching" and "model fitting".
Use case 2: Allows us to use ATLAS prediction packages to fetch data on machine 1, but run analysis on machine 2.

Let me know, if this functionality already exists when using the prediction packages and I have just overlooked it. Otherwise, I propose something as in the commit attached; the flag will need to be passed through to the `execute()` function in `Main.R` of the prediction packages. I am happy to provide a pull request for that as well with some additional checks (e.g. creating a shiny should not be possible when only fetching data, etc.).

The rest of the prediction package is written already with a lot of checks, so if the plpData is present, it will just use that by default without fetching it again.