### PR TITLE
Learning curve improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,5 +87,5 @@ Remotes:
     ohdsi/BigKnn
 LinkingTo: Rcpp
 NeedsCompilation: yes
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/R/LearningCurve.R
+++ b/R/LearningCurve.R
@@ -154,6 +154,7 @@ createLearningCurve <- function(population,
     result <- do.call(runPlp, settings)  
     
     executeTime <- result$executionSummary$TotalExecutionElapsedTime
+    nPredictors <- sum(abs(result$model$model$coefficients) > 0)
     
     result <- as.data.frame(result$performanceEvaluation$evaluationStatistics)
 
@@ -171,6 +172,8 @@ createLearningCurve <- function(population,
     df <- df[-grep('auc_',df$name),]
     
     df <- reshape2::dcast(df, x~ name)
+    
+    df$nPredictors <- nPredictors
   
     # return data frame row for each run
     return(df)
@@ -200,8 +203,9 @@ createLearningCurve <- function(population,
     "TrainBrierScore",
     "TrainCalibrationInLarge",
     "TrainCalibrationIntercept",
-    "TrainCalibrationSlope"
-  )
+    "TrainCalibrationSlope",
+    "nPredictors"
+    )
 
   
   endTime <- Sys.time()
@@ -386,7 +390,8 @@ createLearningCurvePar <- function(population,
     "TrainBrierScore",
     "TrainCalibrationInLarge",
     "TrainCalibrationIntercept",
-    "TrainCalibrationSlope"
+    "TrainCalibrationSlope",
+    "nPredictors"
   )
 
   endTime <- Sys.time()
@@ -416,6 +421,8 @@ lcWrapper <- function(settings){
   )
   if(!is.null(result)){
     executeTime = result$executionSummary$TotalExecutionElapsedTime
+    nPredictors <- sum(abs(result$model$model$coefficients) > 0)
+    
     result = as.data.frame(result$performanceEvaluation$evaluationStatistics)
     
     dfr = data.frame( x = settings$trainFraction * 100,
@@ -430,9 +437,14 @@ lcWrapper <- function(settings){
     dfr$name <- gsub('\\.Gradient','',gsub('\\.Intercept', '', dfr$name))
     dfr = dfr[-grep('auc_',dfr$name),]
     
-    final <- reshape2::dcast(dfr, x~ name)
+    dfr <- reshape2::dcast(dfr, x~ name)
+    
+    dfr$nPredictors <- nPredictors
+    
+    final <- dfr
+
     return(final)
   } else{
-    return(rep(0,20))
+    return(rep(0,21))
   }
 }

--- a/R/Plotting.R
+++ b/R/Plotting.R
@@ -1196,8 +1196,8 @@ plotGeneralizability<- function(covariateSummary, fileName=NULL){
 #'   }
 #' @param abscissa Specify the abscissa metric to be plotted:
 #'   \itemize{
+#'     \item{\code{'events'} - use number of events}
 #'     \item{\code{'observations'} - use number of observations}
-#'     \item{\code{'outcomes'} - use number of positive outcomes}
 #'   }
 #' @param plotTitle Title of the learning curve plot.
 #' @param plotSubtitle Subtitle of the learning curve plot.
@@ -1222,7 +1222,7 @@ plotGeneralizability<- function(covariateSummary, fileName=NULL){
 #' @export
 plotLearningCurve <- function(learningCurve,
                               metric = "AUROC",
-                              abscissa = "observations",
+                              abscissa = "events",
                               plotTitle = "Learning Curve", 
                               plotSubtitle = NULL,
                               fileName = NULL){
@@ -1267,10 +1267,10 @@ plotLearningCurve <- function(learningCurve,
   
   if (abscissa == "observations") {
     abscissa <- "Observations"
-    abscissaLabel <- "Training set size"
-  } else if (abscissa == "outcomes") {
+    abscissaLabel <- "No. of observations"
+  } else if (abscissa == "events") {
     abscissa <- "Occurrences"
-    abscissaLabel <- "Positive outcomes"
+    abscissaLabel <- "No. of events"
   } else {
     stop("An incorrect abscissa has been specified.")
   }

--- a/man/plotLearningCurve.Rd
+++ b/man/plotLearningCurve.Rd
@@ -7,7 +7,7 @@
 plotLearningCurve(
   learningCurve,
   metric = "AUROC",
-  abscissa = "observations",
+  abscissa = "events",
   plotTitle = "Learning Curve",
   plotSubtitle = NULL,
   fileName = NULL
@@ -27,8 +27,8 @@ function.}
 
 \item{abscissa}{Specify the abscissa metric to be plotted:
 \itemize{
+  \item{\code{'events'} - use number of events}
   \item{\code{'observations'} - use number of observations}
-  \item{\code{'outcomes'} - use number of positive outcomes}
 }}
 
 \item{plotTitle}{Title of the learning curve plot.}


### PR DESCRIPTION
Some minor improvements to the existing learning curve code base:

- The plotting function now uses conventions and terminology as used in our learning curve publication.
- The learning curve object has been extended by a column to now also return the number of predictors (`nPredictors`) for each data point.

@jreps I have been a bit confused by the implementation of the melted learning curve data frame, which is then pivoted. Therefore, I added the new column `nPredictors` at the end of the code, when the data frame row was already pivoted and is about to be returned. It is working fine now, but if you manage to add the `nPredictors` column before pivoting, that would make it more consistent.

(To avoid confusion, this pull request does not fix the call to `utils::memory.size()`, which causes warning on macOS and Ubuntu as discussed in the issue)