### PR TITLE
Evaluate model in custom age strata

### DIFF
--- a/R/RunMultiplePlp.R
+++ b/R/RunMultiplePlp.R
@@ -63,6 +63,8 @@
 #' @param testSplit                      How to split into test/train (time or person)
 #' @param testFraction                   Fraction of data to use as test set
 #' @param splitSeed                      The seed used for the randomization into test/train
+#' @param evalAgePop                     Additionally evaluate the fitted model in age stratified subgroups of full population,
+#'                                       e.g. to evaluate in 0-64 years and 65-100 years provide: list(c(0, 64), c(65, 100))
 #' @param nfold                          Number of folds used to do cross validation
 #' @param verbosity                      The logging level
 #' @param settings                       Specify the T, O, population, covariate and model settings
@@ -98,6 +100,7 @@ runPlpAnalyses <- function(connectionDetails,
                           testSplit = "person",
                           testFraction = 0.25,
                           splitSeed = NULL,
+                          evalAgePop = NULL,
                           nfold = 3,
                           verbosity = "INFO",
                           settings = NULL) {
@@ -150,7 +153,7 @@ runPlpAnalyses <- function(connectionDetails,
                            testFraction = testFraction,
                            splitSeed = splitSeed,
                            nfold = nfold,
-                           verbosity = verbosity )
+                           verbosity = verbosity)
 
   if (!dir.exists(outputFolder)){
     dir.create(outputFolder)
@@ -262,6 +265,7 @@ runPlpAnalyses <- function(connectionDetails,
       runPlpSettings$modelSettings <- modelAnalysisList$models[[referenceTable$modelSettingId[i]]]
       runPlpSettings$plpData <- plpData
       runPlpSettings$population <- population
+      runPlpSettings$evalAgePop <- evalAgePop
       runPlpSettings$saveDirectory <- gsub(paste0('/Analysis_',referenceTable$analysisId[i]),'',referenceTable$plpResultFolder[i])
       runPlpSettings$analysisId <- paste0('Analysis_',referenceTable$analysisId[i])
       runPlpSettings$savePlpData <- F

--- a/R/SaveLoadPlp.R
+++ b/R/SaveLoadPlp.R
@@ -733,7 +733,7 @@ loadPlpResult <- function(dirPath){
     result <- c(result, evalAgePop = list(readRDS(file = file.path(dirPath, "evalAgePop.rds"))))
   }
   if(file.exists(file.path(dirPath, "evalAgePred.rds"))) {
-    result<- c(result, evalAgePred = readRDS(file = file.path(dirPath, "evalAgePred.rds")))
+    result<- c(result, evalAgePred = list(readRDS(file = file.path(dirPath, "evalAgePred.rds"))))
   }
   
   class(result) <- "runPlp"

--- a/R/SaveLoadPlp.R
+++ b/R/SaveLoadPlp.R
@@ -695,7 +695,12 @@ savePlpResult <- function(result, dirPath){
   #saveRDS(result$performanceEvaluationTrain, file = file.path(dirPath, "performanceEvaluationTrain.rds"))
   saveRDS(result$covariateSummary, file = file.path(dirPath, "covariateSummary.rds"))
   
-  
+  if(exists('evalAgePop', where=result)) {
+    saveRDS(result$evalAgePop, file = file.path(dirPath, "evalAgePop.rds"))
+  }
+  if(exists("evalAgePred", where=result)) {
+    saveRDS(result$evalAgePred, file = file.path(dirPath, "evalAgePred.rds"))
+  }
 }
 
 #' Loads the evalaution dataframe
@@ -722,6 +727,15 @@ loadPlpResult <- function(dirPath){
                  #performanceEvaluationTrain= readRDS(file.path(dirPath, "performanceEvaluationTrain.rds")),
                  covariateSummary = readRDS(file.path(dirPath, "covariateSummary.rds"))
   )
+  
+  # if evaluation in age strata has been performed, load the relevant list items
+  if(file.exists(file.path(dirPath, 'evalAgePop.rds'))) {
+    result <- c(result, evalAgePop = list(readRDS(file = file.path(dirPath, "evalAgePop.rds"))))
+  }
+  if(file.exists(file.path(dirPath, "evalAgePred.rds"))) {
+    result<- c(result, evalAgePred = readRDS(file = file.path(dirPath, "evalAgePred.rds")))
+  }
+  
   class(result) <- "runPlp"
   
   return(result)

--- a/man/runPlp.Rd
+++ b/man/runPlp.Rd
@@ -24,6 +24,7 @@ runPlp(
   verbosity = "INFO",
   timeStamp = FALSE,
   analysisId = NULL,
+  evalAgePop = NULL,
   runCovariateSummary = T,
   save = NULL
 )
@@ -94,6 +95,9 @@ If not set trainFraction is equal to 1 - test}
 \item{timeStamp}{If TRUE a timestamp will be added to each logging statement. Automatically switched on for TRACE level.}
 
 \item{analysisId}{Identifier for the analysis. It is used to create, e.g., the result folder. Default is a timestamp.}
+
+\item{evalAgePop}{Additionally evaluate the fitted model in age stratified subgroups of full population,
+e.g. to evaluate in 0-64 years and 65-100 years provide: list(c(0, 64), c(65, 100))}
 
 \item{runCovariateSummary}{Whether to calculate the mean and sd for each covariate}
 

--- a/man/runPlpAnalyses.Rd
+++ b/man/runPlpAnalyses.Rd
@@ -28,6 +28,7 @@ runPlpAnalyses(
   testSplit = "person",
   testFraction = 0.25,
   splitSeed = NULL,
+  evalAgePop = NULL,
   nfold = 3,
   verbosity = "INFO",
   settings = NULL
@@ -96,6 +97,9 @@ the \code{\link{createPlpModelSettings}} function.}
 \item{testFraction}{Fraction of data to use as test set}
 
 \item{splitSeed}{The seed used for the randomization into test/train}
+
+\item{evalAgePop}{Additionally evaluate the fitted model in age stratified subgroups of full population,
+e.g. to evaluate in 0-64 years and 65-100 years provide: list(c(0, 64), c(65, 100))}
 
 \item{nfold}{Number of folds used to do cross validation}
 


### PR DESCRIPTION
When developing a (baseline) model on a large age range (0-99 years), we sometimes observe good discrimination performance across the entire age range, but poor discrimination performance in age strata. For example, a model could work great for the age range from 0-64, but poorly for persons 65-99.

The commits in this pull request extend the `runPlp()` function to allow users to provide a list of age strata that the developed model is evaluated on (in addition to evaluating the full population as is already done). This code is intended to not break existing implementations, if `NULL` is provided to the new `evalAgePop` parameter of `runPlp()`. (Even if `NULL` is provided everything should work. The implementation really just adds new items to the PLP results object.)

**Example**: In order to evaluate the developed model on the age strata of people aged 0-64 and 65-99, the following value should be provided `evalAgePop = list(c(0, 64), c(65, 99))`.

@jreps I tested this implementation and it would be great if we could move it to the `master` branch.  For an EMA study I require external data centres to run this and it is always nice to have it in the `master`. Could you have a brief pass through the changes and let me know, if you see any major problems that you could foresee for existing code?

There are a number of ToDo items, which I am going to work on in the coming weeks once the EMA study concludes. I discussed with @PRijnbeek that it may be interesting to follow up on some of the results of applying models in age strata or to different genders.
- Add functionality to evaluate model for female and male population
- Update logger output to reflect that models are being evaluated on age strata
- Make objects provided to `evalAgePop` more intuitive to use
- Add input checks for `evalAgePop` parameter
- Add unit test cases