### PR TITLE
fixed subjectSplitter and added test for subjects unassigned to folds

### DIFF
--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -330,11 +330,13 @@ subjectSplitter <- function(population, test = 0.3, train = NULL, nfold = 3, see
   nonPplGroup <- rep(0, length(nonPpl))
   
   # set test set (index=-1)
-  testInd <- 1:round(length(nonPpl) * test)
+  # use floor(x + 0.5) to get rounding to nearest integer 
+  # instead of to nearest even number when x is .5
+  testInd <- 1:floor(length(nonPpl) * test + 0.5) 
   nonPplGroup[testInd] <- -1
   
   # set train set (index>0)
-  trainInd <- round(length(nonPpl) * test + length(nonPpl) * (1-train-test) + 1):length(nonPpl) 
+  trainInd <- floor(length(nonPpl) * test + length(nonPpl) * (1-train-test) + 1.5):length(nonPpl) 
   reps <- floor(length(trainInd)/nfold)
   leftOver <- length(trainInd)%%nfold
   if (leftOver > 0){
@@ -346,9 +348,9 @@ subjectSplitter <- function(population, test = 0.3, train = NULL, nfold = 3, see
   
   # same for outcome = 1
   outPplGroup <- rep(0, length(outPpl))
-  testInd <- 1:round(length(outPpl) * test)
+  testInd <- 1:floor(length(outPpl) * test + 0.5)
   outPplGroup[testInd] <- -1
-  trainInd <- round(length(outPpl) * test + length(outPpl) * (1-train-test) + 1):length(outPpl)
+  trainInd <- floor(length(outPpl) * test + length(outPpl) * (1-train-test) + 1.5):length(outPpl)
   reps <- floor(length(trainInd)/nfold)
   leftOver <- length(trainInd)%%nfold
   if (leftOver > 0){

--- a/tests/testthat/test-dataSplitting.R
+++ b/tests/testthat/test-dataSplitting.R
@@ -133,13 +133,16 @@ test_that("Data splitting by subject", {
 
 # test that people are not in multiple folds
   DSpopulation3 <- data.frame(rowId=1:200,subjectId = rep(1:50,4), outcomeCount=c(rep(1,42),rep(0,158)))
-  test <- subjectSplitter(DSpopulation3, test=0.2, nfold=3)
+  test <- subjectSplitter(DSpopulation3, test=0.25, nfold=3)
   test <- merge(DSpopulation3, test)
 
   expect_equal(unique(table(test$subjectId[test$index==-1])), 4)
   expect_equal(unique(table(test$subjectId[test$index==2])), 4)
   expect_equal(unique(table(test$subjectId[test$index==3])), 4)
   expect_equal(unique(table(test$subjectId[test$index==1])), 4)
+  
+# test that no subject is not assigned a fold
+  expect_equal(sum(test$index==0), 0)
 
 
 })


### PR DESCRIPTION
There was an issue with the subjectSplitter function. 

It uses the R function round() to get indices for the train and test set. But when the expression inside the round ends in a .5 this function rounds to the nearest even number. For example if it was 20.5 the rounding would result in 20. So the test set would for example go from 1:20. But then for the training set we add 1 to the index, so it's 21.5 and then the rounding gives 22. So the training set is from 22 and upwards. So subject 21 is left out.  

I first added a test to test this situation and indeed it failed with the current code. Then I modified the code so it always rounds up when the expression ends in .5. Then the test passed.

I ran the tests for all the data-splitting functions and they all pass. But I'm struggling to run all of the tests for the package, is there guidance somewhere on how to do that?

Egill 