### PR TITLE
[issue242] fix .data related error

### DIFF
--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -230,7 +230,7 @@ dataSummary <- function(data){
   
   ParallelLogger::logInfo('Train Set:')
   result <- data$Train$labels %>% 
-    dplyr::inner_join(data$Train$folds, by = .data$rowId) %>% 
+    dplyr::inner_join(data$Train$folds, by = 'rowId') %>% 
     dplyr::group_by(.data$index) %>%
     dplyr::summarise(N = length(.data$outcomeCount),
       outcomes = sum(.data$outcomeCount)) %>% 


### PR DESCRIPTION
An error occurred in this step of the dataSummary function (in DataSplitting.R) as below. 

```r
result <- data$Train$labels %>% 
    dplyr::inner_join(data$Train$folds, by = .data$rowId) %>% 
    dplyr::group_by(.data$index) %>%
    dplyr::summarise(N = length(.data$outcomeCount),
      outcomes = sum(.data$outcomeCount)) %>% 
    dplyr::collect()
```

![image](https://user-images.githubusercontent.com/42205861/153182176-e4844831-bca9-436b-bc44-ed9c16d3b12d.png)

After I picked the column directly as 'by = 'rowId' ' than 'by = .data$rowId', the error resolved.

```r
result <- data$Train$labels %>% 
    dplyr::inner_join(data$Train$folds, by = 'rowId') %>% 
    dplyr::group_by(.data$index) %>%
    dplyr::summarise(N = length(.data$outcomeCount),
      outcomes = sum(.data$outcomeCount)) %>% 
    dplyr::collect()
```

