### PR TITLE
Smooth calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,5 +89,5 @@ Remotes:
     ohdsi/ParallelLogger
 LinkingTo: Rcpp
 NeedsCompilation: yes
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/R/Plotting.R
+++ b/R/Plotting.R
@@ -1086,48 +1086,15 @@ plotSmoothCalibration <- function(plpResult,
   } else {
     # use calibrationSummary
     sparsePred <- plpResult$performanceEvaluation$calibrationSummary %>% 
-      dplyr::filter(.data[[typeColumn]] == evalType)
-    
-    limVal <- max(
-      max(sparsePred$averagePredictedProbability),
-      max(sparsePred$observedIncidence)
-    )
-    
-    smoothPlot <- ggplot2::ggplot(
-      data = sparsePred,
-      ggplot2::aes(
-        x = .data$averagePredictedProbability, 
-        y = .data$observedIncidence)
-    ) +
-      ggplot2::stat_smooth(
-        ggplot2::aes(color = "Loess", linetype = "Loess"),
-        method = "loess",
-        se = TRUE,
-        size = 1,
-        show.legend = F
-      ) +
-      ggplot2::geom_segment(
-        ggplot2::aes(
-          x = 0,
-          xend = 1,
-          y = 0,
-          yend = 1,
-          color = "Ideal",
-          linetype = "Ideal"
+      dplyr::filter(.data[[typeColumn]] == evalType) %>%
+      dplyr::rename(
+        c(
+          "y" = "observedIncidence",
+          "p" = "averagePredictedProbability"
         )
-      ) +
-      ggplot2::coord_cartesian(
-        xlim = c(0,limVal),
-        ylim = c(0,limVal)) + 
-      ggplot2::scale_linetype_manual(
-        name = "Models",
-        values = c(
-          Loess = "solid",
-          Ideal = "dashed"
-        )
-      ) + 
-      ggplot2::scale_color_manual(name = "Models", values = c(Loess = "blue", Ideal = "red")) + 
-      ggplot2::labs(x = "Predicted Probability", y = "Observed Probability")
+      )
+
+    smoothPlot <- plotSmoothCalibrationLoess(data = sparsePred)
     
     # construct the plot grid
     if (scatter) {

--- a/man/plotSmoothCalibration.Rd
+++ b/man/plotSmoothCalibration.Rd
@@ -8,7 +8,7 @@ was defined: from utopia to empirical data" (2016)}
 plotSmoothCalibration(
   plpResult,
   smooth = "loess",
-  span = 1,
+  span = 0.75,
   nKnots = 5,
   scatter = FALSE,
   type = "test",
@@ -16,7 +16,7 @@ plotSmoothCalibration(
   sample = TRUE,
   typeColumn = "evaluation",
   saveLocation = NULL,
-  fileName = NULL
+  fileName = "smoothCalibration.pdf"
 )
 }
 \arguments{
@@ -43,6 +43,10 @@ computing and lower memory usage.}
 \item{typeColumn}{The name of the column specifying the evaluation type}
 
 \item{saveLocation}{Directory to save plot (if NULL plot is not saved)}
+
+\item{fileName}{Name of the file to save to plot, for example
+'plot.png'. See the function \code{ggsave} in the ggplot2 package for
+supported file formats.}
 
 \item{zoom}{Zoom in on the region containing the deciles or on the data. If not specified
 shows the entire space.}

--- a/man/plotSmoothCalibration.Rd
+++ b/man/plotSmoothCalibration.Rd
@@ -7,14 +7,14 @@ was defined: from utopia to empirical data" (2016)}
 \usage{
 plotSmoothCalibration(
   plpResult,
-  smooth = c("loess", "rcs"),
+  smooth = "loess",
   span = 1,
   nKnots = 5,
-  scatter = F,
+  scatter = FALSE,
   type = "test",
   bins = 20,
-  zoom = c("none", "deciles", "data"),
-  sample = T,
+  zoom = "none",
+  sample = TRUE,
   typeColumn = "evaluation",
   saveLocation = NULL,
   fileName = NULL
@@ -47,10 +47,6 @@ shows the entire space.}
 \item{typeColumn}{The name of the column specifying the evaluation type}
 
 \item{saveLocation}{Directory to save plot (if NULL plot is not saved)}
-
-\item{fileName}{Name of the file to save to plot, for example
-'plot.png'. See the function \code{ggsave} in the ggplot2 package for
-supported file formats.}
 }
 \value{
 A ggplot object.

--- a/man/plotSmoothCalibration.Rd
+++ b/man/plotSmoothCalibration.Rd
@@ -13,7 +13,6 @@ plotSmoothCalibration(
   scatter = FALSE,
   type = "test",
   bins = 20,
-  zoom = "none",
   sample = TRUE,
   typeColumn = "evaluation",
   saveLocation = NULL,
@@ -39,14 +38,14 @@ computing and lower memory usage.}
 
 \item{bins}{The number of bins for the histogram. Default is 20.}
 
-\item{zoom}{Zoom in on the region containing the deciles or on the data. If not specified
-shows the entire space.}
-
 \item{sample}{If using loess then by default 20,000 patients will be sampled to save time}
 
 \item{typeColumn}{The name of the column specifying the evaluation type}
 
 \item{saveLocation}{Directory to save plot (if NULL plot is not saved)}
+
+\item{zoom}{Zoom in on the region containing the deciles or on the data. If not specified
+shows the entire space.}
 }
 \value{
 A ggplot object.

--- a/tests/testthat/test-plotting_updated.R
+++ b/tests/testthat/test-plotting_updated.R
@@ -20,7 +20,7 @@ context("Plotting")
 #TODO: add input checks and test these...
 #options(fftempdir = getwd())
 
-
+if (FALSE) {
 test_that("plots", {
 
   # test all the outputs are ggplots
@@ -86,9 +86,9 @@ test_that("plotPlp", {
   expect_true(length(dir(file.path(saveLoc,'plots')))>0)
   
 })
-
+}
   
-if(F){
+if(T){
 test_that("plotSmoothCalibration", {
   
   # test the plot works
@@ -101,7 +101,7 @@ test_that("plotSmoothCalibration", {
                                 bins = 20,
                                 zoom = "none",
     saveLocation = NULL)
-  testthat::expect_s3_class(test, c( "gtable", "gTree",  "grob",   "gDesc" ))
+  testthat::expect_s3_class(test[[1]][[1]], c("gg", "ggplot"))
   
   pred <- plpResult$prediction
   plpResult$prediction <- NULL
@@ -115,20 +115,20 @@ test_that("plotSmoothCalibration", {
                         zoom = "data",
                         sample = T,
                         saveLocation = NULL) 
-  testthat::expect_s3_class(test2, c( "gtable", "gTree",  "grob",   "gDesc" ))
+  testthat::expect_s3_class(test2[[1]][[1]], c("gg", "ggplot"))
   plpResult$prediction <- pred
   
   # this fails:
-  #test2 <- plotSmoothCalibration(result = plpResultReal,
-  #                              smooth = "rcs",
-  #                              span = 1,
-  #                              nKnots = 5,
-  #                              scatter = F,
-  #                              type = "test",
-  #                              bins = 20,
-  #                              zoom = "data",
-  #                              fileName = NULL)
-  #testthat::expect_s3_class(test2, 'ggplot')
+  test3 <- plotSmoothCalibration(plpResult,
+                                smooth = "rcs",
+                                span = 1,
+                                nKnots = 5,
+                                scatter = F,
+                                type = "test",
+                                bins = 20,
+                                zoom = "data",
+                                fileName = NULL)
+  testthat::expect_s3_class(test3[[1]][[1]], c("gg", "ggplot"))
   
 })
 

--- a/tests/testthat/test-plotting_updated.R
+++ b/tests/testthat/test-plotting_updated.R
@@ -20,7 +20,6 @@ context("Plotting")
 #TODO: add input checks and test these...
 #options(fftempdir = getwd())
 
-if (FALSE) {
 test_that("plots", {
 
   # test all the outputs are ggplots
@@ -78,7 +77,7 @@ test_that("plotPlp", {
     plpResult  = plpResult, 
     saveLocation = file.path(saveLoc, 'plots'),
     typeColumn = 'evaluation'
-    )
+  )
   testthat::expect_equal(test, T)
   testthat::expect_equal(dir.exists(file.path(saveLoc,'plots')), T)
   
@@ -86,53 +85,60 @@ test_that("plotPlp", {
   expect_true(length(dir(file.path(saveLoc,'plots')))>0)
   
 })
-}
-  
-if(T){
+
 test_that("plotSmoothCalibration", {
   
   # test the plot works
-  test <- plotSmoothCalibration(plpResult = plpResult, 
-                                smooth = "loess",
-                                span = 1,
-                                nKnots = 5,
-                                scatter = T,
-                                type = "test",
-                                bins = 20,
-                                zoom = "none",
-    saveLocation = NULL)
-  testthat::expect_s3_class(test[[1]][[1]], c("gg", "ggplot"))
+  test <- plotSmoothCalibration(
+    plpResult = plpResult, 
+    smooth = "loess",
+    span = 1,
+    nKnots = 5,
+    scatter = T,
+    type = "test",
+    bins = 20,
+    saveLocation = file.path(saveLoc, "plots")
+  )
+  testthat::expect_s3_class(test$test$smoothPlot, c("gg", "ggplot"))
+  testthat::expect_s3_class(test$test$histPlot, c("gg", "ggplot"))
+  testthat::expect_true(
+    file.exists(
+      file.path(saveLoc, "plots", "smoothCalibrationTest.pdf")
+    )
+  )
   
   pred <- plpResult$prediction
   plpResult$prediction <- NULL
   test2 <- plotSmoothCalibration(plpResult,
-                        smooth = "loess",
-                        span = 1,
-                        nKnots = 5,
-                        scatter = T,
-                        type = "test",
-                        bins = 20,
-                        zoom = "data",
-                        sample = T,
-                        saveLocation = NULL) 
-  testthat::expect_s3_class(test2[[1]][[1]], c("gg", "ggplot"))
+    smooth = "loess",
+    span = 1,
+    nKnots = 5,
+    scatter = T,
+    type = "test",
+    bins = 20,
+    sample = T,
+    saveLocation = NULL) 
+  testthat::expect_s3_class(test2$test$smoothPlot, c("gg", "ggplot"))
   plpResult$prediction <- pred
   
-  # this fails:
   test3 <- plotSmoothCalibration(plpResult,
-                                smooth = "rcs",
-                                span = 1,
-                                nKnots = 5,
-                                scatter = F,
-                                type = "test",
-                                bins = 20,
-                                zoom = "data",
-                                fileName = NULL)
-  testthat::expect_s3_class(test3[[1]][[1]], c("gg", "ggplot"))
+    smooth = "rcs",
+    span = 1,
+    nKnots = 5,
+    scatter = F,
+    type = "test",
+    bins = 20,
+    fileName = NULL)
+  testthat::expect_s3_class(test3$test$smoothPlot, c("gg", "ggplot"))
+  testthat::expect_s3_class(test3$test$histPlot, c("gg", "ggplot"))
+  testthat::expect_true(
+    file.exists(
+      file.path(saveLoc, "plots", "smoothCalibrationTest.pdf")
+    )
+  )
   
 })
 
-}
 
 
 


### PR DESCRIPTION
Fixing issues with `plotSmoothCalibration` function:
- Fix restricted cubic spline plotting
- Attempt to modularize with the addition of `plotSmoothCalibrationLoess` and `plotSmoothCalibrationRcs` functions
- Remove zoom option and always plot using limits (0, 1)
- Return a list of `ggplot` plots per evaluation type that can be further manipulated (theming etc)
  - `$smoothPlot` the plot with the smooth calibration
  - `$histPlot` the plot with the outcome count histograms
- Update the tests (they should not be failing now)
