### PR TITLE
Load json cyclops fix - faster tests - fixes of various test failures

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -79,15 +79,15 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
-      - name: use r-reticulate environment
-        run: |
-          reticulate::use_condaenv("r-reticulate", required = TRUE)
-        shell: Rscript {0}
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          
+      - name: use r-reticulate environment
+        run: |
+          reticulate::use_condaenv("r-reticulate", required = TRUE)
+        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -61,71 +61,39 @@ jobs:
       - name: python scikit-survival dependencies    
         run: conda install --name r-reticulate -c sebp scikit-survival
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
       - uses: r-lib/actions/setup-tinytex@v1
 
       - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-3-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-3-
-  
-      - name: Install system dependencies
+      
+      - name: Install system requirements
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get install -y libssh-dev
+          Rscript -e 'install.packages("remotes")'
           while read -r cmd
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE, INSTALL_opts=c("--no-multiarch"))
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Install covr
-        if: runner.os == 'Windows'
-        run: |
-          remotes::install_cran("covr")
-        shell: Rscript {0}
-
-      - name: Remove check folder if exists
-        if: runner.os == 'macOS'
-        run: unlink("check", recursive = TRUE)
-        shell: Rscript {0}
-
       - name: use r-reticulate environment
         run: |
           reticulate::use_condaenv("r-reticulate", required = TRUE)
         shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--no-multiarch"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+        
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"warning"'
+          check-dir: '"check"'
 
       - name: Upload source package
         if: success() && runner.os == 'macOS' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -133,6 +101,12 @@ jobs:
         with:
           name: package_tarball
           path: check/*.tar.gz
+          
+      - name: Install covr
+        if: runner.os == 'Windows'
+        run: |
+          remotes::install_cran("covr")
+        shell: Rscript {0}
 
       - name: Test coverage
         if: runner.os == 'Windows'

--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -336,13 +336,16 @@ createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, 
 
   if (is.character(fit)) {
     coefficients <- c(0)
+    names(coefficients) <- ''
     status <- fit
   } else if (fit$return_flag == "ILLCONDITIONED") {
     coefficients <- c(0)
+    names(coefficients) <- ''
     status <- "ILL CONDITIONED, CANNOT FIT"
     ParallelLogger::logWarn(paste("GLM fitting issue: ", status))
   } else if (fit$return_flag == "MAX_ITERATIONS") {
     coefficients <- c(0)
+    names(coefficients) <- ''
     status <- "REACHED MAXIMUM NUMBER OF ITERATIONS, CANNOT FIT"
     ParallelLogger::logWarn(paste("GLM fitting issue: ", status))
   } else {

--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -284,11 +284,11 @@ predictCyclopsType <- function(coefficients, population, covariateData, modelTyp
     stop("Needs correct covariateData")
   }
   
-  intercept <- coefficients[names(coefficients)%in%'(Intercept)']
+  intercept <- coefficients$betas[coefficients$covariateId%in%'(Intercept)']
   if(length(intercept)==0) intercept <- 0
-  coefficients <- coefficients[!names(coefficients)%in%'(Intercept)']
-  coefficients <- data.frame(beta = as.numeric(coefficients),
-    covariateId = as.numeric(names(coefficients)) #!@ modified 
+  betas <- coefficients$betas[!coefficients$covariateIds%in%'(Intercept)']
+  coefficients <- data.frame(beta = betas,
+    covariateId = coefficients$covariateIds[coefficients$covariateIds!='(Intercept)']
   )
   coefficients <- coefficients[coefficients$beta != 0, ]
   if(sum(coefficients$beta != 0)>0){
@@ -351,12 +351,17 @@ createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, 
     ParallelLogger::logInfo(paste("GLM fit status: ", status))
   }
   
+  # use a dataframe for the coefficients
+  betas <- as.numeric(coefficients)
+  betaNames <- names(coefficients)
+  coefficients <- data.frame(betas=betas, covariateIds=betaNames)
+  
   outcomeModel <- list(
-    coefficients = coefficients, 
     priorVariance = fit$variance,
     log_likelihood = fit$log_likelihood,
     modelType = modelType,
-    modelStatus = status
+    modelStatus = status,
+    coefficients = coefficients
   )
 
   if(modelType == "cox" || modelType == "survival") {
@@ -440,8 +445,8 @@ getCV <- function(
 
 getVariableImportance <- function(modelTrained, trainData){
   varImp <- data.frame(
-    covariateId = as.double(names(modelTrained$coefficients)[names(modelTrained$coefficients)!='(Intercept)']),
-    value = modelTrained$coefficients[names(modelTrained$coefficients)!='(Intercept)']
+    covariateId = as.double(modelTrained$coefficients$covariateIds[modelTrained$coefficients$covariateIds!='(Intercept)']),
+    value = modelTrained$coefficients$betas[modelTrained$coefficients$covariateIds!='(Intercept)']
   )
 
 if(sum(abs(varImp$value)>0)==0){

--- a/R/CyclopsSettings.R
+++ b/R/CyclopsSettings.R
@@ -10,6 +10,7 @@
 #' @param lowerLimit  	Numeric: Lower prior variance limit for grid-search
 #' @param tolerance   Numeric: maximum relative change in convergence criterion from successive iterations to achieve convergence
 #' @param maxIterations 	Integer: maximum iterations of Cyclops to attempt before returning a failed-to-converge error
+#' @param priorCoefs    Use coefficients from a previous model as starting points for model fit (transfer learning)
 #' 
 #' @examples
 #' model.lr <- setLassoLogisticRegression()

--- a/R/EvaluationSummary.R
+++ b/R/EvaluationSummary.R
@@ -333,13 +333,13 @@ computeAuc <- function(prediction,
 }
 
 aucWithCi <- function(prediction, truth){
-  auc <- pROC::auc(as.factor(truth), prediction, direction="<")
+  auc <- pROC::auc(as.factor(truth), prediction, direction="<", quiet=TRUE)
   aucci <-pROC::ci(auc)
   return(data.frame(auc = aucci[2], auc_lb95ci = aucci[1], auc_ub95ci = aucci[3]))
 }
 
 aucWithoutCi <- function(prediction, truth){
-  auc <- pROC::auc(as.factor(truth), prediction, direction="<")
+  auc <- pROC::auc(as.factor(truth), prediction, direction="<", quiet=TRUE)
   return(as.double(auc))
 }
 

--- a/R/ExternalValidatePlp.R
+++ b/R/ExternalValidatePlp.R
@@ -238,7 +238,7 @@ externalValidateDbPlp <- function(
         list(
           plpData = plpData,
           outcomeId = getPlpDataSettings$databaseDetails$outcomeIds,
-          populationSettings = plpModel$settings$populationSettings
+          populationSettings = plpModel$modelDesign$populationSettings
         )
       )
     },

--- a/R/ExternalValidatePlp.R
+++ b/R/ExternalValidatePlp.R
@@ -102,9 +102,9 @@ externalValidatePlp <- function(
       developmentDatabase = plpModel$trainDetails$developmentDatabase,
       validationDatabase = databaseName,
       populationSettings = attr(population, 'metaData')$populationSettings,
-      restrictPlpDataSettings = attr(plpData, 'metaData')$restrictPlpDataSettings,
+      restrictPlpDataSettings = plpData$metaData$restrictPlpDataSettings,
       outcomeId = attr(population, 'metaData')$outcomeId,
-      targetId = attr(plpData, 'metaData')$databaseDetails$targetId,
+      targetId = plpData$metaData$databaseDetails$targetId,
       attrition = attr(population, 'metaData')$attrition,
       validationDate = Sys.Date() # is this needed?
     )

--- a/R/FeatureEngineering.R
+++ b/R/FeatureEngineering.R
@@ -122,7 +122,7 @@ univariateFeatureSelection <- function(
     SelectKBest <- sklearn$feature_selection$SelectKBest
     chi2 <- sklearn$feature_selection$chi2
     
-    kbest <- SelectKBest(chi2, k = featureEngineeringSettings$k)$fit(X, y)
+    kbest <- SelectKBest(chi2, k = featureEngineeringSettings$k)$fit(X, y$outcomeCount)
     kbest$scores_ <- np$nan_to_num(kbest$scores_)
     threshold <- -np$sort(-kbest$scores_)[(featureEngineeringSettings$k-1)]
     
@@ -184,7 +184,7 @@ randomForestFeatureSelection <- function(
     max_depth = featureEngineeringSettings$max_depth #17
     
     rf = sklearn$ensemble$RandomForestClassifier(
-      max_features = 'auto', 
+      max_features = 'sqrt', 
       n_estimators = as.integer(ntrees),
       max_depth = as.integer(max_depth),
       min_samples_split = as.integer(2), 

--- a/R/KNN.R
+++ b/R/KNN.R
@@ -192,7 +192,7 @@ predictKnn <- function(
     all.x=T, fill=0)
   prediction$value[is.na(prediction$value)] <- 0
   
-  attr(prediction, "metaData") <- 'binary'
+  attr(prediction, "metaData")$modelType <- 'binary'
   
   return(prediction)
   

--- a/R/PreprocessingData.R
+++ b/R/PreprocessingData.R
@@ -78,10 +78,11 @@ preprocessData <- function (covariateData,
   preprocessSettings$covariateData <- covariateData
   covariateData <- do.call(FeatureExtraction::tidyCovariateData, preprocessSettings)
   
-  #update covariateRed
-  removed <- unique(
+  #update covariateRef
+  removed <- unique(c(
     attr(covariateData, "metaData")$deletedInfrequentCovariateIds,
     attr(covariateData, "metaData")$deletedRedundantCovariateIds
+    )
     )
   covariateData$covariateRef <- covariateData$covariateRef %>% 
     dplyr::filter(!.data$covariateId  %in% removed)

--- a/R/SaveLoadPlp.R
+++ b/R/SaveLoadPlp.R
@@ -360,9 +360,11 @@ loadPlpResult <- function(dirPath){
   
   result <- readRDS(file.path(dirPath, "runPlp.rds"))
   result$model = loadPlpModel(file.path(dirPath, "model"))
-
-  class(result) <- "runPlp"
   
+  if (is.null(class(result))) {
+    class(result) <- 'runPlp'
+  }
+
   return(result)
   
 }

--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -135,7 +135,10 @@ simulatePlpData <- function(plpDataSimulationProfile, n = 10000) {
   writeLines("Generating outcomes")
   allOutcomes <- data.frame()
   for (i in 1:length(plpDataSimulationProfile$metaData$outcomeIds)) {
-    prediction <- predictCyclopsType(plpDataSimulationProfile$outcomeModels[[i]],
+    coefficients <- data.frame(betas=as.numeric(plpDataSimulationProfile$outcomeModels[[i]]),
+                               covariateIds=names(plpDataSimulationProfile$outcomeModels[[i]])
+                               )
+    prediction <- predictCyclopsType(coefficients,
                                    cohorts,
                                    covariateData,
                                    modelType = "poisson")

--- a/R/ThresholdSummary.R
+++ b/R/ThresholdSummary.R
@@ -81,6 +81,14 @@ getThresholdSummary_binary <- function(prediction, evalColumn, ...){
     # sort prediction
     predictionOfInterest <- predictionOfInterest[order(-predictionOfInterest$value),]
     
+    # because of numerical precision issues (I think), in very rare cases the preferenceScore 
+    # is not monotonically decreasing after this sort (it should follow the predictions)
+    # as a fix I remove the troublesome row from influencing the thresholdSummary
+    if (!all(predictionOfInterest$preferenceScore == cummin(predictionOfInterest$preferenceScore))) {
+      troubleRow <- (which((predictionOfInterest$preferenceScore == cummin(predictionOfInterest$preferenceScore))==FALSE))
+      predictionOfInterest <- predictionOfInterest[-troubleRow,]
+      }
+    
     # create indexes
     if(length(predictionOfInterest$preferenceScore)>100){
       indexesOfInt <- c(
@@ -165,6 +173,7 @@ getThresholdSummary_binary <- function(prediction, evalColumn, ...){
         diagnosticOddsRatio = diagnosticOddsRatio
       )
     )
+    
     
   }
   

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -689,7 +689,7 @@ insertModelInDatabase <- function(
       
       executionDateTime = format(model$trainDetails$trainingDate, format="%Y-%m-%d"), 
       trainingTime = model$trainDetails$trainingTime, 
-      intercept = ifelse(is.list(model$model) & attr(model, 'saveType') != 'xgboost', model$model$coefficients[1], 0),  # using the param useIntercept?
+      intercept = ifelse(is.list(model$model) & attr(model, 'saveType') != 'xgboost', model$model$coefficients$betas[1], 0),  # using the param useIntercept?
       
       tablePrefix = databaseSchemaSettings$tablePrefix,
       tempEmulationSchema = databaseSchemaSettings$tempEmulationSchema

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -957,14 +957,14 @@ getCohortDefinitionJson <- function(cohortDefinitions, cohortId){
 getResultLocations <- function(resultLocation){
   # get the model locations...
   
-  resultLocs <- file.path(
-    dir(
+  resultLocs <- dir(
       resultLocation, 
       pattern = 'Analysis_', 
       full.names = T
-    ), 
-    'plpResult'
   )
+  # automatically find Results folder, to handle both plpResult/ and validationResult/
+  resultLocs <- file.path(resultLocs, dir(resultLocs, pattern='Result'))
+  
   
   if(dir.exists(file.path(resultLocation, 'Validation'))){
     validationDatabases <- dir(file.path(resultLocation, 'Validation'))

--- a/man/setLassoLogisticRegression.Rd
+++ b/man/setLassoLogisticRegression.Rd
@@ -38,6 +38,8 @@ setLassoLogisticRegression(
 \item{tolerance}{Numeric: maximum relative change in convergence criterion from successive iterations to achieve convergence}
 
 \item{maxIterations}{Integer: maximum iterations of Cyclops to attempt before returning a failed-to-converge error}
+
+\item{priorCoefs}{Use coefficients from a previous model as starting points for model fit (transfer learning)}
 }
 \description{
 Create setting for lasso logistic regression

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,7 +1,6 @@
 
 # this files contains the objects used in the tests:
-travis <- T
-if(travis){
+if(Sys.getenv('GITHUB_ACTIONS') == 'TRUE'){
   # Download the PostreSQL driver ---------------------------
   # If DATABASECONNECTOR_JAR_FOLDER exists, assume driver has been downloaded
   jarFolder <- Sys.getenv("DATABASECONNECTOR_JAR_FOLDER", unset = "")

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,6 +1,6 @@
 
 # this files contains the objects used in the tests:
-if(Sys.getenv('GITHUB_ACTIONS') == 'TRUE'){
+if(Sys.getenv('GITHUB_ACTIONS') == 'true'){
   # Download the PostreSQL driver ---------------------------
   # If DATABASECONNECTOR_JAR_FOLDER exists, assume driver has been downloaded
   jarFolder <- Sys.getenv("DATABASECONNECTOR_JAR_FOLDER", unset = "")
@@ -135,16 +135,6 @@ createTrainData <- function(plpData, population){
   
   return(trainData)
 }
-
-
-sampleSize2 <- 1000+sample(1000,1)
-plpData2 <- simulatePlpData(plpDataSimulationProfile, n = sampleSize2)
-
-population2 <- createStudyPopulation(
-  plpData = plpData2,
-  outcomeId = 2, 
-  populationSettings = populationSettings
-)
 
 sampleSizeBig <- 10000
 plpDataBig <- simulatePlpData(plpDataSimulationProfile, n = sampleSizeBig)

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -44,9 +44,8 @@ dir.create(saveLoc)
 data(plpDataSimulationProfile, envir = environment())
 
 # PLPDATA
-sampleSize <- 2500+sample(1000,1)
+sampleSize <- 1000+sample(300,1)
 plpData <- simulatePlpData(plpDataSimulationProfile, n = sampleSize)
-#plpData$metaData$cohortId <- plpData$metaData$cohortIds
 
 # POPULATION
 populationSettings <- createStudyPopulationSettings(
@@ -135,13 +134,3 @@ createTrainData <- function(plpData, population){
   
   return(trainData)
 }
-
-sampleSizeBig <- 10000
-plpDataBig <- simulatePlpData(plpDataSimulationProfile, n = sampleSizeBig)
-
-populationBig <- createStudyPopulation(
-  plpData = plpDataBig,
-  outcomeId = 2, 
-  populationSettings = populationSettings
-)
-

--- a/tests/testthat/test-KNN.R
+++ b/tests/testthat/test-KNN.R
@@ -1,8 +1,14 @@
 
 resultNames <- c('executionSummary','model','prediction', 'performanceEvaluation', 'covariateSummary', 'analysisRef')
 
+# reduce data so test runs quicker, still with at least 10 outcomes in test
+plpDataKNN <- plpData
+plpData$population <- plpData$cohorts[sample(nrow(plpData$cohorts), 400),]
+
+# will fit 100% on training data which produces a warning
+suppressWarnings({
 plpResultKNN <- runPlp(
-  plpData = plpData, 
+  plpData = plpDataKNN, 
   outcomeId = 2, 
   analysisId = 'knnTest', 
   analysisName = 'Testing knn',
@@ -14,6 +20,7 @@ plpResultKNN <- runPlp(
   executeSettings = createDefaultExecuteSettings(), 
   saveDirectory = file.path(saveLoc, 'knn')
   )
+})
 
 test_that("covRef is correct size", {
   

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -18,6 +18,8 @@ library("testthat")
 
 context("UploadToDatabase")
 
+# only run this during CI
+if (Sys.getenv('CI') == 'true') {
 cdmDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_CDM_SCHEMA")
 ohdsiDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_OHDSI_SCHEMA")
 connectionRedshift <- DatabaseConnector::createConnectionDetails(
@@ -34,9 +36,9 @@ appendRandom <- function(x, rand = randVar){
   return(paste(rand, x, sep=''))
 }
 
-
+}
 test_that("test createDatabaseSchemaSettings works", {
-  
+  skip_if(Sys.getenv('CI') != 'true', 'not run locally')
   databaseSchemaSettings <- createDatabaseSchemaSettings(
     resultSchema = ohdsiDatabaseSchema, 
     tablePrefix = '',
@@ -123,7 +125,7 @@ test_that("getCohortDefinitionFromDefinitions", {
 
 
 test_that("database creation", {
-  
+  skip_if(Sys.getenv('CI') != 'true', 'not run locally')
   createPlpResultTables(
     conn = conn, 
     resultSchema = ohdsiDatabaseSchema, 
@@ -141,8 +143,8 @@ test_that("database creation", {
 
 
 test_that("results uploaded to database", {
-  
-  resultsLoc <- file.path(saveLoc,'dbUp')
+  skip_if(Sys.getenv('CI') != 'true', 'not run locally')
+    resultsLoc <- file.path(saveLoc,'dbUp')
   
   plpResult$model$trainDetails$developmentDatabase <- 'test' 
   savePlpResult(plpResult, file.path(resultsLoc, 'Analysis_1','plpResult'))
@@ -194,7 +196,7 @@ test_that("results uploaded to database", {
 
 
 test_that("database deletion", {
-
+  skip_if(Sys.getenv('CI') != 'true', 'not run locally')
   createPlpResultTables(
     conn = conn, 
     resultSchema = ohdsiDatabaseSchema, 
@@ -212,7 +214,9 @@ test_that("database deletion", {
 })
 
 # disconnect
-DatabaseConnector::disconnect(conn)
+if (Sys.getenv('CI') == 'true') {
+  DatabaseConnector::disconnect(conn)
+}
 
 # code to test sqlite creation, result and diagnostic upload all in one
 test_that("temporary sqlite with results works", {

--- a/tests/testthat/test-andromedahelperfunctions.R
+++ b/tests/testthat/test-andromedahelperfunctions.R
@@ -23,8 +23,8 @@ context("AndromedaHelperFunctions")
 # batcheRestrict test 
 test_that("batchRestrict", {
   
-  metaData <- attr(plpDataBig$covariateData, 'metaData')
-  covariateData <- PatientLevelPrediction:::batchRestrict(plpDataBig$covariateData, populationBig, sizeN = 10000000)
+  metaData <- attr(plpData$covariateData, 'metaData')
+  covariateData <- PatientLevelPrediction:::batchRestrict(plpData$covariateData, population, sizeN = 1000000)
   testthat::expect_is(covariateData, 'CovariateData')
   
   expect_equal(names(metaData), names(attr(covariateData, 'metaData')))

--- a/tests/testthat/test-featureImportance.R
+++ b/tests/testthat/test-featureImportance.R
@@ -21,8 +21,14 @@ context("FeatureImportance")
 
 test_that("pfi feature importance returns data.frame", {
   
+  # limit to a sample of 10 covariates for faster test
+  covariates <- plpResult$model$covariateImportance %>% 
+    dplyr::filter(.data$covariateValue != 0) %>% 
+    dplyr::select(.data$covariateId) %>% 
+    dplyr::pull()
+  covariates <- sample(covariates, 10)
   pfiTest <- pfi(plpResult, population, plpData, repeats = 1,
-                  covariates = NULL, cores = NULL, log = NULL,
+                  covariates = covariates, cores = NULL, log = NULL,
                   logthreshold = "INFO")
   
   testthat::expect_equal(class(pfiTest), 'data.frame')

--- a/tests/testthat/test-sklearnClassifier.R
+++ b/tests/testthat/test-sklearnClassifier.R
@@ -78,7 +78,7 @@ test_that("check fit of DecisionTree", {
   expect_true(nrow(plpModel$covariateImportance) < trainData$covariateData$covariateRef %>% dplyr::tally() %>% dplyr::pull())
   
   expect_true(dir.exists(plpModel$model))
-  expect_equal(dir(plpModel$model),"model.json")
+  expect_equal(dir(plpModel$model),"model.pkl")
   
   expect_equal(plpModel$modelDesign$outcomeId,2)
   expect_equal(plpModel$modelDesign$targetId,1)

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -33,7 +33,7 @@ databaseDetails <- createDatabaseDetails(
   outcomeIds = 3, #make this ids
   cdmVersion = 5)
 
-modelVal <- plpResult$model
+modelVal <- loadPlpModel(file.path(saveLoc, 'Test', 'plpResult', 'model'))
 validationDatabaseDetailsVal <- databaseDetails  # from run multiple tests
 validationRestrictPlpDataSettingsVal <- createRestrictPlpDataSettings(washoutPeriod = 0, sampleSize = NULL)
 recalSet <- createValidationSettings(recalibrate = 'weakRecalibration')


### PR DESCRIPTION
Here is the PR I mentioned yesterday for you to review @jreps . 

Features
- Changed cyclops coefficient to use a data.frame with columns ```betas``` and ```covariateIds``` instead of a named vector. 
- Adapted test for external validation to follow real world behavior, almost always you load the model from disk and then validate externally. This would have caught the json saving bug. 
- Added ```quiet=True``` to all AUC calculations, silencing the message that comes everytime you calculate the AUC.

Bugfixes
- Added priorCoefs to documentation since it was failing the R CMD check. 
- Fixed a small bug where the externalValidate wasn't picking up the population settings which caused a test failure 
- There was a hardcoded ```.json``` in the sklearn test, now since that has been turned of it broke a test - I changed it to ```.pkl``` 
- A small bug causing a warning since the KNN metaData wasn't saved correctly.
- Fixed a small bug caused by the cyclops coefficient being a dataframe, the intercept wasn't uploading to the database correctly.
- In ```loadPlpResults``` , it would force the class of the object to be ```runPlp```. Sometimes the loaded object was a ```validatePlp``` object, then the class would be overwritten. Now it only adds the ```runPlp``` class if the class attribute is missing.
- When uploading results to database in validateMultiplePlp , there was an error becauce it was looking for a ```plpResult``` folder when the folder with the results was named ```validateResult```. Now it looks for a folder with ```Result``` in it and picks that.
- In ```externalValidatePlp``` the ```targetId``` wasn't correctly assigned, so it was null - I fixed that.
- The univariateFeatureSelection was failing because the ```y``` object the sklearn function was receiving was wrong.
- When the Cyclops model didn't fit, there was an error when creating the coefficient dataframe because there was only one coefficient ```c(0)``` with a ```NULL``` name. I changed the name in those cases to an empty string.
- There was an occasionally failing test in preprocessing. This happened when there was a redundant covariate to remove but no rare covariates to remove. I think the unique function was then being used incorrectly in ```PreprocessingData.R``` and as a consequence the deleted covariates weren't removed from the covariateRef. 
- Another rare failing test - in the plotting of the preference score. Very rarely I think there was some numerical instability issue which caused the ```preferenceScore``` not to be monotonically increasing/decreasing after sorting by the ```prediction$value```. This caused an error when plotting the ```preferenceScore```

Test improvements
- Test weren't running locally because some tests were for uploading to databases using the github secrets. When running github actions there is an environment variable ```CI``` which is set to ```true```. So I used that to automatically detect if test are running locally or on actions, then it skips those tests that cannot be run locally automatically. 
- Updated the actions workflow to use the new Hades one, got it from DatabaseConnector.  It's a bit faster and simpler. 
- For the KNN test I now sample 400 samples for it to run on to be faster. I do this by adding a population object to the plpData object. I also suppress warnings when the KNN fits 100% on the training set.
- I made the plpData objects created in the test helper smaller. It's now 1000 samples, which in my opinion is enough, then you have about 30 events per fold and 30 in the test set.
- I removed the plpDataBig object, it was only used to test the batchRestrict for Andromeda. IMO this isn't really necessary and the functionality can easily be tested with smaller data objects.
- For testing the permutation feature importance. Instead of using all the covariates now I sample 10 of them to calculate the importance on.  

Now I run the tests locally in around 5 minutes on my linux laptop. The actions now run in about 37 minutes instead of an 1 hour and 15 minutes. I still see occasionally failing tests and warnings but leave that for future work.