### PR TITLE
remove survAUC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,6 @@ Suggests:
     scoring,
     shiny,
     OhdsiShinyModules (>= 0.2.3),
-    survAUC,
     survminer,
     testthat,
     withr,

--- a/R/CyclopsSettings.R
+++ b/R/CyclopsSettings.R
@@ -111,8 +111,6 @@ setCoxModel <- function(
   maxIterations = 3000
 ){
   
-  ensure_installed("survAUC")
-
   checkIsClass(seed, c('numeric','NULL','integer'))
   if(is.null(seed[1])){
     seed <- as.integer(sample(100000000,1))


### PR DESCRIPTION
@jreps  I removed the survAUC dependancy which wasn't used anymore. This finally gets rid of Hmisc  and rms so @rekkasa work pays off in reduced dependencies for PLP.