### PR TITLE
pass seed to cyclops and add priorType to getCV

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: PatientLevelPrediction
 Type: Package
 Title: Developing patient level prediction using data in the OMOP Common Data
     Model
-Version: 6.0.4
+Version: 6.0.5
 Date: 2022-10-05
 Authors@R: c(
     person("Jenna", "Reps", email = "jreps@its.jnj.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+PatientLevelPrediction 6.0.5
+======================
+- Allow priorType to be passed down to getCV function in case prior is not 'laplace'
+- Seed specified in Cyclops model wasn't passed to Cyclops
+
 PatientLevelPrediction 6.0.4
 ======================
 - forcing cdmDatabaseId to be a string if integer is input

--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -100,7 +100,8 @@ fitCyclopsModel <- function(
       selectorType = settings$selectorType,
       noiseLevel = "silent",
       threads = settings$threads,
-      maxIterations = settings$maxIterations
+      maxIterations = settings$maxIterations,
+      seed = settings$seed
       )
     
     fit <- tryCatch({
@@ -128,7 +129,8 @@ fitCyclopsModel <- function(
     useCrossValidation = max(trainData$folds$index)>1, 
     cyclopsData = cyclopsData, 
     labels = trainData$covariateData$labels,
-    folds = trainData$folds
+    folds = trainData$folds,
+    priorType = param$priorParams$priorType
     )
   
   if (!is.null(param$priorCoefs)) {
@@ -333,7 +335,8 @@ predictCyclopsType <- function(coefficients, population, covariateData, modelTyp
 }
 
 
-createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, labels, folds){
+createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, labels, folds,
+                               priorType){
 
   if (is.character(fit)) {
     coefficients <- c(0)
@@ -380,7 +383,8 @@ createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, 
   
   #get CV
   if(modelType == "logistic" && useCrossValidation){
-    outcomeModel$cv <- getCV(cyclopsData, labels, cvVariance = fit$variance, folds = folds)
+    outcomeModel$cv <- getCV(cyclopsData, labels, cvVariance = fit$variance, folds = folds,
+                             priorType = priorType)
   }
   
   return(outcomeModel)
@@ -413,10 +417,13 @@ getCV <- function(
   cyclopsData, 
   labels,
   cvVariance,
-  folds
+  folds,
+  priorType
 )
 {
-  fixed_prior <- Cyclops::createPrior("laplace", variance = cvVariance, useCrossValidation = FALSE)
+  fixed_prior <- Cyclops::createPrior(priorType = priorType, 
+                                      variance = cvVariance, 
+                                      useCrossValidation = FALSE)
   
   # add the index to the labels
   labels <- merge(labels, folds, by = 'rowId')


### PR DESCRIPTION
- Adds priorType to getCV in CyclopsModels.R . It was hardcoded as 'laplace' but for different models such as ridge or IHT that won't work. Now it gets the priorType from the modelSettings
- Fix a small bug with the seed given to Cyclops models. It wasn't actually passed to cyclops but should be now
- Updated news with these changes and updated version to 6.0.5

All test passed locally.