### PR TITLE
Univariate fix

### DIFF
--- a/R/FeatureEngineering.R
+++ b/R/FeatureEngineering.R
@@ -54,7 +54,11 @@ createFeatureEngineeringSettings <- function(type = 'none'){
 #' @export
 createUnivariateFeatureSelection <- function(k = 100){
   
-  checkIsClass(k, c('numeric','integer'))
+  if (inherits(k, 'numeric')) {
+    k <- as.integer(k)
+  }
+  
+  checkIsClass(k, 'integer')
   checkHigherEqual(k, 0)
   
   featureEngineeringSettings <- list(k = k) 


### PR DESCRIPTION
fixes 2 out of 3 failing tests reported in #343 

The cause was a new scikit-learn version adding a check for an input that should be an integer, but in older versions didn't check and worked both with numerics and integers.

I've not so far been able to reproduce the last failing test.

@jreps can you review and merge this?