### PR TITLE
Scikit learn fixes

### DIFF
--- a/R/GradientBoostingMachine.R
+++ b/R/GradientBoostingMachine.R
@@ -228,7 +228,7 @@ fitXgboost <- function(
   outcomes <- sum(labels$outcomeCount>0)
   N <- nrow(labels)
   outcomeProportion <- outcomes/N
-  
+  set.seed(settings$seed)
   model <- xgboost::xgb.train(
     data = train, 
     params = list(

--- a/R/SklearnClassifier.R
+++ b/R/SklearnClassifier.R
@@ -246,7 +246,7 @@ gridCvPython <- function(
   )
   {
   
-  ParallelLogger::logInfo(paste0("Rnning CV for ",modelName," model"))
+  ParallelLogger::logInfo(paste0("Running CV for ",modelName," model"))
  
   np <- reticulate::import('numpy')
   os <- reticulate::import('os')

--- a/R/SklearnClassifierSettings.R
+++ b/R/SklearnClassifierSettings.R
@@ -32,7 +32,6 @@
 #' }
 #' @export
 setAdaBoost <- function(
-  #baseEstimator = list(NULL),
   nEstimators = list(10,50, 200), 
   learningRate = list(1, 0.5, 0.1), 
   algorithm = list('SAMME.R'),
@@ -43,8 +42,6 @@ setAdaBoost <- function(
   checkIsClass(nEstimators, 'list')
   checkIsClass(learningRate, 'list')
   checkIsClass(algorithm, 'list')
-  
-  #lapply(1:length(baseEstimator), function(i) checkIsClass(maxDepth[[i]] , c("NULL")))
   
   lapply(1:length(nEstimators), function(i) checkIsClass(nEstimators[[i]] , c("integer", "numeric")))
   lapply(1:length(nEstimators), function(i) checkHigher(nEstimators[[i]] , 0))
@@ -64,7 +61,6 @@ setAdaBoost <- function(
   ##checkPython()
   
   paramGrid <- list(
-    baseEstimator = list(NULL),
     nEstimators = nEstimators,
     learningRate = learningRate,
     algorithm = algorithm,
@@ -100,7 +96,6 @@ setAdaBoost <- function(
 AdaBoostClassifierInputs <- function(classifier, param){
   
   model <- classifier(
-    base_estimator = param[[which.max(names(param)=='baseEstimator')]],
     n_estimators = param[[which.max(names(param)=='nEstimators')]],
     learning_rate = param[[which.max(names(param)=='learningRate')]],
     algorithm = param[[which.max(names(param)=='algorithm')]],

--- a/R/SklearnClassifierSettings.R
+++ b/R/SklearnClassifierSettings.R
@@ -133,7 +133,7 @@ setDecisionTree <- function(
   maxFeatures = list(100,'sqrt', NULL),
   maxLeafNodes = list(NULL),
   minImpurityDecrease = list(10^-7),
-  classWeight = list(NULL, 'balanced'),
+  classWeight = list(NULL),
   seed = sample(1000000,1)
   ){
   if(!inherits(x = seed[[1]], what = c('numeric', 'integer'))){
@@ -560,7 +560,7 @@ setRandomForest <- function(
   maxSamples = list(NULL, 0.9),
   oobScore = list(FALSE),
   nJobs = list(NULL),
-  classWeight = list('balanced_subsample', NULL),
+  classWeight = list(NULL),
   seed = sample(100000,1)
   ){
   
@@ -685,7 +685,7 @@ RandomForestClassifierInputs <- function(classifier, param){
     oob_score = param[[which.max(names(param)=='oobScore')]],
     n_jobs = param[[which.max(names(param)=='nJobs')]],
     random_state = param[[which.max(names(param)=='seed')]],
-    verbose = 0,
+    verbose = 0L,
     warm_start = F,
     class_weight = param[[which.max(names(param)=='classWeight')]]
   )
@@ -720,7 +720,7 @@ setSVM <- function(
   coef0 = list(0.0),
   shrinking = list(TRUE), 
   tol = list(0.001),
-  classWeight = list('balanced', NULL), 
+  classWeight = list(NULL), 
   cacheSize  = 500,
   seed = sample(100000,1)
   ){

--- a/R/SklearnClassifierSettings.R
+++ b/R/SklearnClassifierSettings.R
@@ -336,7 +336,7 @@ setMLP <- function(
   validationFraction = list(0.1),
   beta1 = list(0.9), 
   beta2 = list(0.999), 
-  epsilon = list(1,0.1,0.00000001), 
+  epsilon = list(0.00000001), 
   nIterNoChange = list(10),
   seed = sample(100000,1)
   ){

--- a/man/setDecisionTree.Rd
+++ b/man/setDecisionTree.Rd
@@ -14,7 +14,7 @@ setDecisionTree(
   maxFeatures = list(100, "sqrt", NULL),
   maxLeafNodes = list(NULL),
   minImpurityDecrease = list(10^-7),
-  classWeight = list(NULL, "balanced"),
+  classWeight = list(NULL),
   seed = sample(1e+06, 1)
 )
 }

--- a/man/setMLP.Rd
+++ b/man/setMLP.Rd
@@ -23,7 +23,7 @@ setMLP(
   validationFraction = list(0.1),
   beta1 = list(0.9),
   beta2 = list(0.999),
-  epsilon = list(1, 0.1, 1e-08),
+  epsilon = list(1e-08),
   nIterNoChange = list(10),
   seed = sample(1e+05, 1)
 )

--- a/man/setRandomForest.Rd
+++ b/man/setRandomForest.Rd
@@ -18,7 +18,7 @@ setRandomForest(
   maxSamples = list(NULL, 0.9),
   oobScore = list(FALSE),
   nJobs = list(NULL),
-  classWeight = list("balanced_subsample", NULL),
+  classWeight = list(NULL),
   seed = sample(1e+05, 1)
 )
 }

--- a/man/setSVM.Rd
+++ b/man/setSVM.Rd
@@ -12,7 +12,7 @@ setSVM(
   coef0 = list(0),
   shrinking = list(TRUE),
   tol = list(0.001),
-  classWeight = list("balanced", NULL),
+  classWeight = list(NULL),
   cacheSize = 500,
   seed = sample(1e+05, 1)
 )

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,0 +1,29 @@
+# common tests that can be grouped together, such as the output from fitplp
+
+expect_correct_fitPlp <- function(plpModel, trainData, outputRisk=TRUE) {
+  
+  # predictions are same amount as labels
+  expect_equal(nrow(trainData$labels)*2, nrow(plpModel$prediction))
+  
+  # get predictions both for train and CV
+  expect_equal(length(unique(plpModel$prediction$evaluationType)), 2)
+
+  # predictions are all between 0 and 1
+  if (outputRisk) {
+    expect_true(all((plpModel$prediction$value>=0) & (plpModel$prediction$value<1)))
+  }
+  else {
+    expect_true(all((plpModel$prediction$value==0) | (plpModel$prediction$value==1)))
+  }
+  
+  expect_true(nrow(plpModel$covariateImportance) < 
+              trainData$covariateData$covariateRef %>% 
+              dplyr::tally() %>% 
+              dplyr::pull())
+  
+  expect_true(dir.exists(plpModel$model))
+  expect_equal(dir(plpModel$model),"model.pkl")
+  
+  expect_equal(plpModel$modelDesign$outcomeId,2)
+  expect_equal(plpModel$modelDesign$targetId,1)
+}

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -19,3 +19,12 @@ expect_correct_fitPlp <- function(plpModel, trainData) {
   expect_equal(names(plpModel), c("model", "preprocessing", "prediction",
                                   "modelDesign", "trainDetails", "covariateImportance"))
 }
+
+expect_correct_predictions <- function(predictions, testData) {
+  
+  # predictions are all between 0 and 1
+  expect_true(all((predictions$value>=0) & (predictions$value<=1)))
+  expect_equal(NROW(testData$labels), NROW(predictions))
+  
+  
+}

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,29 +1,21 @@
-# common tests that can be grouped together, such as the output from fitplp
+# common tests that can be grouped together, such as testing the output from fitplp
 
-expect_correct_fitPlp <- function(plpModel, trainData, outputRisk=TRUE) {
+expect_correct_fitPlp <- function(plpModel, trainData) {
   
   # predictions are same amount as labels
-  expect_equal(nrow(trainData$labels)*2, nrow(plpModel$prediction))
+  multiplicativeFactor <- dplyr::n_distinct(plpModel$prediction %>% dplyr::pull(evaluationType))
+  expect_equal(NROW(trainData$labels)*multiplicativeFactor, NROW(plpModel$prediction))
   
-  # get predictions both for train and CV
-  expect_equal(length(unique(plpModel$prediction$evaluationType)), 2)
-
   # predictions are all between 0 and 1
-  if (outputRisk) {
-    expect_true(all((plpModel$prediction$value>=0) & (plpModel$prediction$value<1)))
-  }
-  else {
-    expect_true(all((plpModel$prediction$value==0) | (plpModel$prediction$value==1)))
-  }
-  
-  expect_true(nrow(plpModel$covariateImportance) < 
-              trainData$covariateData$covariateRef %>% 
-              dplyr::tally() %>% 
-              dplyr::pull())
-  
+  expect_true(all((plpModel$prediction$value>=0) & (plpModel$prediction$value<=1)))
+
+  # model directory exists
   expect_true(dir.exists(plpModel$model))
-  expect_equal(dir(plpModel$model),"model.pkl")
   
   expect_equal(plpModel$modelDesign$outcomeId,2)
   expect_equal(plpModel$modelDesign$targetId,1)
+  
+  # structure of plpModel is correct
+  expect_equal(names(plpModel), c("model", "preprocessing", "prediction",
+                                  "modelDesign", "trainDetails", "covariateImportance"))
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -1,5 +1,6 @@
 # helper functions for tests
 
+# copies trainData and makes sure andromeda object is copied correctly 
 copyTrainData <- function(trainData) {
   newTrainData <- trainData
   
@@ -8,4 +9,25 @@ copyTrainData <- function(trainData) {
 
   class(newTrainData$covariateData) <- class(trainData$covariateData)
   return(newTrainData)
+}
+
+# create tiny dataset with subset of covariates based on lasso fit
+createTinyPlpData <- function(plpData, plpResult) {
+  
+  covariates <- plpResult$model$covariateImportance %>% 
+    dplyr::slice_max(order_by = abs(covariateValue),n = 20, with_ties=F) %>% 
+    dplyr::pull(covariateId)
+  tinyPlpData <- plpData
+  tinyPlpData$covariateData <- Andromeda::copyAndromeda(plpData$covariateData)
+  
+  tinyPlpData$covariateData$covariates <- plpData$covariateData$covariates %>% 
+    dplyr::filter(covariateId %in% covariates)
+  tinyPlpData$covariateData$covariateRef <- plpData$covariateData$covariateRef %>% 
+    dplyr::filter(covariateId %in% covariates)
+  
+  attributes(tinyPlpData$covariateData)$metaData <- attributes(plpData$covariateData)$metaData
+  class(tinyPlpData$covariateData) <- class(plpData$covariateData)
+  attributes(tinyPlpData)$metaData <- attributes(plpData)$metaData
+  class(tinyPlpData) <- class(plpData)
+  return(tinyPlpData)
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -1,0 +1,11 @@
+# helper functions for tests
+
+copyTrainData <- function(trainData) {
+  newTrainData <- trainData
+  
+  # force andromeda to copy
+  newTrainData$covariateData <- Andromeda::copyAndromeda(trainData$covariateData)
+
+  class(newTrainData$covariateData) <- class(trainData$covariateData)
+  return(newTrainData)
+}

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -114,9 +114,35 @@ createTrainData <- function(plpData, population){
   return(trainData)
 }
 
+trainData <- createTrainData(plpData, population)
+
 createTestData <- function(plpData, population){
   data <- PatientLevelPrediction::splitData(plpData = plpData, population=population,
                                             splitSettings = PatientLevelPrediction::createDefaultSplitSetting(splitSeed = 12))
   testData <- data$Test
   return(testData)
 }
+
+testData <- createTestData(plpData, population)
+
+# reduced trainData to only use 10 most important features (as decided by LR)
+reduceTrainData <- function(trainData) {
+  covariates <- plpResult$model$covariateImportance %>% 
+    dplyr::slice_max(order_by = abs(covariateValue),n = 10) %>% 
+    dplyr::pull(covariateId)
+  
+  reducedTrainData <- list(labels = trainData$labels,
+                           folds = trainData$folds,
+                           covariateData = Andromeda::andromeda(
+                             analysisRef = trainData$covariateData$analysisRef
+                           ))
+  
+  
+  reducedTrainData$covariateData$covariates <- trainData$covariateData$covariates %>% 
+    dplyr::filter(covariateId %in% covariates)
+  reducedTrainData$covariateData$covariateRef <- trainData$covariateData$covariateRef %>% 
+    dplyr::filter(covariateId %in% covariates)
+  return(reducedTrainData)  
+}
+
+reducedTrainData <- reduceTrainData(trainData)

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -142,7 +142,11 @@ reduceTrainData <- function(trainData) {
     dplyr::filter(covariateId %in% covariates)
   reducedTrainData$covariateData$covariateRef <- trainData$covariateData$covariateRef %>% 
     dplyr::filter(covariateId %in% covariates)
+  
+  attributes(reducedTrainData$covariateData)$metaData <- attributes(trainData$covariateData)$metaData
+  class(reducedTrainData$covariateData) <- class(trainData$covariateData)
+  attributes(reducedTrainData)$metaData <- attributes(trainData)$metaData
   return(reducedTrainData)  
 }
 
-reducedTrainData <- reduceTrainData(trainData)
+tinyTrainData <- reduceTrainData(trainData)

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -128,7 +128,7 @@ testData <- createTestData(plpData, population)
 # reduced trainData to only use 10 most important features (as decided by LR)
 reduceTrainData <- function(trainData) {
   covariates <- plpResult$model$covariateImportance %>% 
-    dplyr::slice_max(order_by = abs(covariateValue),n = 10) %>% 
+    dplyr::slice_max(order_by = abs(covariateValue),n = 20, with_ties = F) %>% 
     dplyr::pull(covariateId)
   
   reducedTrainData <- list(labels = trainData$labels,
@@ -150,3 +150,6 @@ reduceTrainData <- function(trainData) {
 }
 
 tinyTrainData <- reduceTrainData(trainData)
+
+tinyPlpData <- createTinyPlpData(plpData, plpResult)
+

--- a/tests/testthat/test-KNN.R
+++ b/tests/testthat/test-KNN.R
@@ -1,45 +1,18 @@
 
-resultNames <- c('executionSummary','model','prediction', 'performanceEvaluation', 'covariateSummary', 'analysisRef')
 
-# reduce data so test runs quicker, still with at least 10 outcomes in test
-plpDataKNN <- plpData
-plpDataKNN$population <- plpData$cohorts[sample(nrow(plpData$cohorts), 400),]
-
-# will fit 100% on training data which produces a warning
-suppressWarnings({
-plpResultKNN <- runPlp(
-  plpData = plpDataKNN, 
-  outcomeId = 2, 
-  analysisId = 'knnTest', 
-  analysisName = 'Testing knn',
-  populationSettings = populationSettings, 
-  splitSettings = createDefaultSplitSetting(),
-  preprocessSettings = createPreprocessSettings(), 
-  modelSettings = setKNN(k=10), 
-  logSettings = createLogSettings(verbosity = 'TRACE'),
-  executeSettings = createDefaultExecuteSettings(), 
-  saveDirectory = file.path(saveLoc, 'knn')
+test_that('KNN fit works', {
+  modelSettings = setKNN(k=5)
+  
+  plpModel <- fitPlp(
+    trainData = tinyTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'KNN'
   )
-})
-
-test_that("covRef is correct size", {
   
-  testthat::expect_true(nrow(plpDataKNN$covariateData$covariateRef %>% dplyr::collect()) >=  
-    nrow(plpResultKNN$model$covariateImportance))
+  expect_correct_fitPlp(plpModel, tinyTrainData) 
   
 })
 
-
-test_that("KNN results have correct structure", {
-  
-  
-  # same output names for LR, KNN and GBM
-  testthat::expect_equal(
-    names(plpResultKNN),
-    resultNames
-    )
-  
-})
 
 test_that("KNN settings", {
 

--- a/tests/testthat/test-cyclopsModels.R
+++ b/tests/testthat/test-cyclopsModels.R
@@ -239,7 +239,6 @@ testthat::expect_error(setIterativeHardThresholding(seed = 'F'))
 test_that("test logistic regression runs", {
 
 modelSettings <- setLassoLogisticRegression()
-trainData <- createTrainData(plpData, population)
 
 fitModel <- fitPlp(
   trainData = trainData,   
@@ -251,6 +250,8 @@ fitModel <- fitPlp(
 expect_equal(length(unique(fitModel$prediction$evaluationType)),2)
 expect_equal(nrow(fitModel$prediction), nrow(trainData$labels)*2)
 expect_true(length(fitModel$model$coefficients) < trainData$covariateData$covariateRef %>% dplyr::tally() %>% dplyr::pull()+1)
+
+
 expect_true(!is.null(fitModel$trainDetails$trainingTime))
 expect_equal(fitModel$trainDetails$trainingDate,Sys.Date())
 

--- a/tests/testthat/test-featureEngineering.R
+++ b/tests/testthat/test-featureEngineering.R
@@ -153,7 +153,7 @@ test_that("randomForestFeatureSelection", {
 })
 
 test_that("featureSelection is applied on test_data", {
-  k <- 10
+  k <- 20
   featureEngineeringSettings <- testUniFun(k = k)
   newTrainData <- copyTrainData(trainData)
   newTrainData <- univariateFeatureSelection(

--- a/tests/testthat/test-featureEngineering.R
+++ b/tests/testthat/test-featureEngineering.R
@@ -18,8 +18,6 @@ library("testthat")
 context("FeatureEngineering")
 
 
-trainData <- createTrainData(plpData, population)
-
 testFEFun <- function(type = 'none'){
   
   result <- createFeatureEngineeringSettings(type = type)
@@ -79,13 +77,11 @@ test_that("univariateFeatureSelection", {
   newDataCovariateSize <- reducedTrainData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull()
   expect_true(newDataCovariateSize <= trainDataCovariateSize)
   
-  # expect k many covariates left - REMOVED AS TIES MAKES THIS FAIL OCCASIONALLY
+  # expect k many covariates left
   expect_equal(k,reducedTrainData$covariateData$covariateRef %>% dplyr::tally() %>% dplyr::pull())
   
 })
 
-# refresh the training data
-trainData <- createTrainData(plpData, population)
 
 test_that("createRandomForestFeatureSelection correct class", {
   ntreesTest <- sample(1000,1)

--- a/tests/testthat/test-featureEngineering.R
+++ b/tests/testthat/test-featureEngineering.R
@@ -153,7 +153,6 @@ test_that("randomForestFeatureSelection", {
 test_that("featureSelection is applied on test_data", {
   k <- 10
   featureEngineeringSettings <- testUniFun(k = k)
-  trainData <- createTrainData(plpData, population)
   trainData <- univariateFeatureSelection(
     trainData = trainData, 
     featureEngineeringSettings = featureEngineeringSettings,

--- a/tests/testthat/test-featureEngineering.R
+++ b/tests/testthat/test-featureEngineering.R
@@ -65,11 +65,12 @@ test_that("univariateFeatureSelection", {
   
   k <- 20+sample(10,1)
   featureEngineeringSettings <- testUniFun(k = k)
+  newTrainData <- copyTrainData(trainData)
   
-  trainDataCovariateSize <- trainData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull()
+  trainDataCovariateSize <- newTrainData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull()
   
   reducedTrainData <- univariateFeatureSelection(
-    trainData = trainData, 
+    trainData = newTrainData, 
     featureEngineeringSettings = featureEngineeringSettings,
     covariateIdsInclude = NULL
     )
@@ -137,10 +138,11 @@ test_that("randomForestFeatureSelection", {
     maxDepth = maxDepthTest
   )
   
-  trainDataCovariateSize <- trainData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull()
+  newTrainData <- copyTrainData(trainData)
+  trainDataCovariateSize <- newTrainData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull()
   
   reducedTrainData <- randomForestFeatureSelection(
-    trainData = trainData, 
+    trainData = newTrainData, 
     featureEngineeringSettings = featureEngineeringSettings,
     covariateIdsInclude = NULL
   )
@@ -153,8 +155,9 @@ test_that("randomForestFeatureSelection", {
 test_that("featureSelection is applied on test_data", {
   k <- 10
   featureEngineeringSettings <- testUniFun(k = k)
-  trainData <- univariateFeatureSelection(
-    trainData = trainData, 
+  newTrainData <- copyTrainData(trainData)
+  newTrainData <- univariateFeatureSelection(
+    trainData = newTrainData, 
     featureEngineeringSettings = featureEngineeringSettings,
     covariateIdsInclude = NULL
   )
@@ -163,12 +166,11 @@ test_that("featureSelection is applied on test_data", {
   
   # added try catch due to model sometimes not fitting
   plpModel <- tryCatch(
-    {fitPlp(trainData, modelSettings, analysisId='FE')}, 
+    {fitPlp(newTrainData, modelSettings, analysisId='FE')}, 
     error = function(e){return(NULL)}
   )
   
   if(!is.null(plpModel)){ # if the model fit then check this
-    testData <- createTestData(plpData, population)
     prediction <- predictPlp(plpModel, testData, population)
     expect_true(attr(prediction, 'metaData')$featureEngineering) 
   }

--- a/tests/testthat/test-featureImportance.R
+++ b/tests/testthat/test-featureImportance.R
@@ -23,8 +23,8 @@ test_that("pfi feature importance returns data.frame", {
   
   # limit to a sample of 10 covariates for faster test
   covariates <- plpResult$model$covariateImportance %>% 
-    dplyr::filter(.data$covariateValue != 0) %>% 
-    dplyr::select(.data$covariateId) %>% 
+    dplyr::filter("covariateValue" != 0) %>% 
+    dplyr::select("covariateId") %>% 
     dplyr::pull()
   
   # if the model had non-zero covariates

--- a/tests/testthat/test-featureImportance.R
+++ b/tests/testthat/test-featureImportance.R
@@ -34,9 +34,35 @@ test_that("pfi feature importance returns data.frame", {
                    covariates = covariates, cores = NULL, log = NULL,
                    logthreshold = "INFO")
     
-    testthat::expect_equal(class(pfiTest), 'data.frame')
-    testthat::expect_equal(sum(names(pfiTest)%in%c("covariateId", "pfi")), 2)
+    expect_equal(class(pfiTest), 'data.frame')
+    expect_equal(sum(names(pfiTest)%in%c("covariateId", "pfi")), 2)
+    expect_true(all(!is.nan(pfiTest$pfi)))
+    
   }
   
+})
+
+test_that('pfi feature importance works with logger or without covariates', {
+  tinyResults <- runPlp(plpData = tinyPlpData,
+                        populationSettings = populationSettings,
+                        outcomeId = 2,
+                        analysisId = 'tinyFit',
+                        featureEngineeringSettings = createUnivariateFeatureSelection(k=20),
+                        executeSettings = createExecuteSettings(
+                          runSplitData = T,
+                          runSampleData = F,
+                          runfeatureEngineering = T,
+                          runPreprocessData = T,
+                          runModelDevelopment = T,
+                          runCovariateSummary = F
+                        ))
+  
+  pfiTest <- pfi(tinyResults, population, tinyPlpData, 
+                 covariates = NULL, log = file.path(tempdir(), 'pfiLog'))
+  
+  expect_equal(class(pfiTest), 'data.frame')
+  expect_equal(sum(names(pfiTest)%in%c("covariateId", "pfi")), 2)
+  expect_true(all(!is.nan(pfiTest$pfi)))
+
 })
 

--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -18,7 +18,6 @@ library("testthat")
 
 context("Fitting")
 
-trainData <- createTrainData(plpData, population)
 modelSettings <- setLassoLogisticRegression()
 
 test_that("fitPlp", {

--- a/tests/testthat/test-learningCurves.R
+++ b/tests/testthat/test-learningCurves.R
@@ -72,7 +72,7 @@ test_that("getTrainFractions works", {
     modelSettings = setLassoLogisticRegression(),
     saveDirectory =  file.path(saveLoc, 'lcc'),
     splitSettings = createDefaultSplitSetting(testFraction = 0.33, nfold=2), 
-    trainEvents = c(100,150),
+    trainEvents = c(150,200),
     preprocessSettings = createPreprocessSettings(
       minFraction = 0.001,
       normalize = T

--- a/tests/testthat/test-learningCurves.R
+++ b/tests/testthat/test-learningCurves.R
@@ -19,11 +19,11 @@ context("LearningCurves")
 # learningCurve 
 learningCurve <- PatientLevelPrediction::createLearningCurve(
   plpData = plpData,
-  outcomeId = 2, parallel = F, cores = 3,
+  outcomeId = 2, parallel = F, cores = -1,
   modelSettings = setLassoLogisticRegression(),
   saveDirectory =  file.path(saveLoc, 'lcc'),
-  splitSettings = createDefaultSplitSetting(testFraction = 0.2), 
-  trainFractions = c(0.6,0.7,0.8),
+  splitSettings = createDefaultSplitSetting(testFraction = 0.2, nfold=2), 
+  trainFractions = c(0.6,0.7),
   trainEvents = NULL,
   preprocessSettings = createPreprocessSettings(
     minFraction = 0.001,
@@ -42,7 +42,7 @@ test_that("learningCurve output correct", {
     "Train_populationSize",
     "Train_outcomeCount") ),5)
   
-  testthat::expect_equal(learningCurve$trainFraction,  c(0.6,0.7,0.8)*100)
+  testthat::expect_equal(learningCurve$trainFraction,  c(0.6,0.7)*100)
   
 })
 
@@ -64,4 +64,27 @@ test_that("plotLearningCurve", {
   
 })
 
+test_that("getTrainFractions works", {
+  
+  learningCurve <- PatientLevelPrediction::createLearningCurve(
+    plpData = tinyPlpData,
+    outcomeId = 2, parallel = F, cores = -1,
+    modelSettings = setLassoLogisticRegression(),
+    saveDirectory =  file.path(saveLoc, 'lcc'),
+    splitSettings = createDefaultSplitSetting(testFraction = 0.33, nfold=2), 
+    trainEvents = c(100,150),
+    preprocessSettings = createPreprocessSettings(
+      minFraction = 0.001,
+      normalize = T
+    )
+  )
+  testthat::expect_true(is.data.frame(learningCurve))
+  testthat::expect_equal(sum(colnames(learningCurve)%in%c(
+    "trainFraction",
+    "Train_AUROC",
+    "nPredictors",
+    "Train_populationSize",
+    "Train_outcomeCount") ),5)
+  
+})
 

--- a/tests/testthat/test-preprocessingData.R
+++ b/tests/testthat/test-preprocessingData.R
@@ -58,7 +58,6 @@ test_that("createPreprocessSettings", {
 })
 
 test_that("createPreprocessSettings", {
-  trainData <- createTrainData(plpData, population)
   attr(trainData$covariateData, "metaData")$preprocessSettings <- NULL # removing for test
   metaData <- attr(trainData$covariateData, "metaData")
   metaLength <- length(metaData)
@@ -86,7 +85,6 @@ test_that("createPreprocessSettings", {
   
   expect_equal(newFeatureCount, oldFeatureCount)
   
-  trainData <- createTrainData(plpData, population)
   oldFeatureCount <- trainData$covariateData$covariateRef %>% dplyr::tally() %>% dplyr::pull()
   
   metaData <- attr(trainData$covariateData, "metaData")

--- a/tests/testthat/test-rclassifier.R
+++ b/tests/testthat/test-rclassifier.R
@@ -88,7 +88,6 @@ testthat::expect_error(setGradientBoostingMachine(scalePosWeight = -1))
 
 test_that("GBM working checks", {
   
-  trainData <- createTrainData(plpData = plpData, population = population)
   modelSettings <- setGradientBoostingMachine(ntrees = 10, maxDepth = 3, learnRate = 0.1)
   
   fitModel <- fitPlp(

--- a/tests/testthat/test-sampling.R
+++ b/tests/testthat/test-sampling.R
@@ -99,17 +99,17 @@ test_that("createSampleSettings expected errors", {
 
 test_that("sampleData outputs are correct", {
   
-  trainData <- createTrainData(plpData, population)
-  attr(trainData, "metaData")$sampleSettings <- NULL # remove for test
+  newTrainData <- trainData
+  attr(newTrainData, "metaData")$sampleSettings <- NULL # remove for test
   
   sampleSettings <- sampleSettingFunc(type = 'none') 
   
-  sampleData <- sampleData(trainData, sampleSettings)
+  sampleData <- sampleData(newTrainData, sampleSettings)
   
   # make sure metaData captures
   expect_equal(
     length(attr(sampleData, "metaData")),
-    length(attr(trainData, "metaData"))+1
+    length(attr(newTrainData, "metaData"))+1
   )
   
   expect_equal(
@@ -120,17 +120,17 @@ test_that("sampleData outputs are correct", {
   # check the data is the same:
   expect_equal(
     nrow(sampleData$labels), 
-    nrow(trainData$labels)
+    nrow(newTrainData$labels)
   )
   
   expect_equal(
     nrow(sampleData$folds), 
-    nrow(trainData$folds)
+    nrow(newTrainData$folds)
   )
   
   expect_equal(
     sampleData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull(), 
-    trainData$covariateData$covariates  %>% dplyr::tally() %>% dplyr::pull()
+    newTrainData$covariateData$covariates  %>% dplyr::tally() %>% dplyr::pull()
   )
   
   
@@ -141,7 +141,7 @@ test_that("sampleData outputs are correct", {
  
 test_that("underSampleData works", {
   
-  trainData <- createTrainData(plpData, population)
+  newTrainData <- trainData
   
   sampleSettings <- list(
     sampleSeed = 1,
@@ -153,12 +153,15 @@ test_that("underSampleData works", {
   expect_true(inherits(underSampleData, 'plpData')) # add test based on github issue
   
   # the sampled data should be smaller...
-  expect_true(nrow(underSampleData$labels) <= nrow(trainData$labels))
+  expect_true(nrow(underSampleData$labels) <= nrow(newTrainData$labels))
   
-  expect_true(nrow(underSampleData$folds) <= nrow(trainData$folds))
+  expect_true(nrow(underSampleData$folds) <= nrow(newTrainData$folds))
   
   expect_true(
-    underSampleData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull() <= trainData$covariateData$covariates  %>% dplyr::tally() %>% dplyr::pull()
+    underSampleData$covariateData$covariates %>% 
+      dplyr::tally() %>% 
+      dplyr::pull() <= newTrainData$covariateData$covariates  %>% 
+      dplyr::tally() %>% dplyr::pull()
   )
   
   # perhaps add manual data test
@@ -169,24 +172,26 @@ test_that("underSampleData works", {
 
 test_that("overSampleData works", {
   
-  trainData <- createTrainData(plpData, population)
+  newTrainData <- trainData
   
   sampleSettings <- list(
     sampleSeed = 1,
     numberOutcomestoNonOutcomes = 0.5
   )
   
-  overSampleData <- overSampleData(trainData, sampleSettings)
+  overSampleData <- overSampleData(newTrainData, sampleSettings)
   
   expect_true(inherits(overSampleData, 'plpData')) # add test based on github issue
   
   # the sampled data should be smaller...
-  expect_true(nrow(overSampleData$labels) >= nrow(trainData$labels))
+  expect_true(nrow(overSampleData$labels) >= nrow(newTrainData$labels))
   
-  expect_true(nrow(overSampleData$folds) >= nrow(trainData$folds))
+  expect_true(nrow(overSampleData$folds) >= nrow(newTrainData$folds))
   
   expect_true(
-    overSampleData$covariateData$covariates %>% dplyr::tally() %>% dplyr::pull() >= trainData$covariateData$covariates  %>% dplyr::tally() %>% dplyr::pull()
+    overSampleData$covariateData$covariates %>% dplyr::tally() %>% 
+      dplyr::pull() >= newTrainData$covariateData$covariates  %>% 
+      dplyr::tally() %>% dplyr::pull()
   )
   
   # perhaps add manual data test

--- a/tests/testthat/test-sklearnClassifier.R
+++ b/tests/testthat/test-sklearnClassifier.R
@@ -62,7 +62,7 @@ test_that("check fit of DecisionTree", {
   )
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'DecisionTree'
     )
@@ -72,7 +72,7 @@ test_that("check fit of DecisionTree", {
   
 })
 
-# add tests for other classifiers
+
 test_that('AdaBoost fit works', {
   
   modelSettings <- setAdaBoost(nEstimators = list(10),
@@ -80,12 +80,13 @@ test_that('AdaBoost fit works', {
                                )
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'Adaboost'
   )
   
   expect_correct_fitPlp(plpModel, trainData)
+  expect_equal(dir(plpModel$model),"model.pkl")
   
 })
 
@@ -101,12 +102,13 @@ test_that('RandomForest fit works', {
                                    classWeight = list(NULL))
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'RandomForest'
   )
   
   expect_correct_fitPlp(plpModel, trainData)
+  expect_equal(dir(plpModel$model),"model.pkl")
   
 })
 
@@ -122,12 +124,14 @@ test_that('MLP fit works', {
   )
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'MLP'
   )
   
   expect_correct_fitPlp(plpModel, trainData)
+  expect_equal(dir(plpModel$model),"model.pkl")
+  
 })
 
 
@@ -135,12 +139,13 @@ test_that('Naive bayes fit works', {
   modelSettings <- setNaiveBayes()
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'Naive bayes'
   )
   
-  expect_correct_fitPlp(plpModel, trainData, outputRisk=FALSE) 
+  expect_correct_fitPlp(plpModel, trainData) 
+  expect_equal(dir(plpModel$model),"model.pkl")
   
 })
 
@@ -152,10 +157,12 @@ test_that('Support vector machine fit works', {
                           classWeight = list(NULL))
   
   plpModel <- fitPlp(
-    trainData = reducedTrainData, 
+    trainData = tinyTrainData, 
     modelSettings = modelSettings,
     analysisId = 'SVM'
   )
   
   expect_correct_fitPlp(plpModel, trainData) 
+  expect_equal(dir(plpModel$model),"model.pkl")
+  
 })

--- a/tests/testthat/test-sklearnClassifier.R
+++ b/tests/testthat/test-sklearnClassifier.R
@@ -9,16 +9,16 @@ dtset <- setDecisionTree(
   minSamplesSplit = list(2, 10),
   minSamplesLeaf = list(10, 50),
   minWeightFractionLeaf = list(0),
-  maxFeatures = list(100,'auto', NULL),
+  maxFeatures = list(100,'sqrt', NULL),
   maxLeafNodes = list(NULL),
   minImpurityDecrease = list(10^-7),
-  classWeight = list(NULL, 'balanced'),
+  classWeight = list(NULL),
   seed = sample(1000000,1)
 )
 
 expect_equal(dtset$fitFunction, "fitSklearn")
 
-expect_equal(length(dtset$param), 3*2*2*3*2)
+expect_equal(length(dtset$param), 3*2*2*3*1)
 
 expect_equal(unique(unlist(lapply(dtset$param, function(x) x[[1]]))), 'gini')
 expect_equal(unique(unlist(lapply(dtset$param, function(x) x[[2]]))), 'best')
@@ -47,7 +47,6 @@ test_that("DecisionTree errors as expected", {
 
 test_that("check fit of DecisionTree", {
   
-  
   modelSettings <- setDecisionTree(
     criterion = list('gini'),
     splitter = list('best'),
@@ -55,36 +54,108 @@ test_that("check fit of DecisionTree", {
     minSamplesSplit = list(2),
     minSamplesLeaf = list(10),
     minWeightFractionLeaf = list(0),
-    maxFeatures = list(as.integer(100),'auto'),
+    maxFeatures = list('sqrt'),
     maxLeafNodes = list(NULL),
     minImpurityDecrease = list(10^-7),
-    classWeight = list(NULL, 'balanced'),
+    classWeight = list(NULL),
     seed = sample(1000000,1)
   )
-  trainData <- createTrainData(
-    plpData = plpData, 
-    population = population
-    )
   
   plpModel <- fitPlp(
-    trainData = trainData, 
+    trainData = reducedTrainData, 
     modelSettings = modelSettings,
     analysisId = 'DecisionTree'
     )
   
-  expect_equal(nrow(trainData$labels)*2, nrow(plpModel$prediction))
-  expect_equal(length(unique(plpModel$prediction$evaluationType)), 2)
-
-  expect_true(nrow(plpModel$covariateImportance) < trainData$covariateData$covariateRef %>% dplyr::tally() %>% dplyr::pull())
-  
-  expect_true(dir.exists(plpModel$model))
-  expect_equal(dir(plpModel$model),"model.pkl")
-  
-  expect_equal(plpModel$modelDesign$outcomeId,2)
-  expect_equal(plpModel$modelDesign$targetId,1)
+  expect_correct_fitPlp(plpModel, trainData)
   # add check for other model design settings
   
 })
 
 # add tests for other classifiers
+test_that('AdaBoost fit works', {
+  
+  modelSettings <- setAdaBoost(nEstimators = list(10),
+                               learningRate = list(0.1),
+                               )
+  
+  plpModel <- fitPlp(
+    trainData = reducedTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'Adaboost'
+  )
+  
+  expect_correct_fitPlp(plpModel, trainData)
+  
+})
 
+
+test_that('RandomForest fit works', {
+  
+  modelSettings <- setRandomForest(ntrees=list(10),
+                                   maxDepth=list(4),
+                                   minSamplesSplit = list(2),
+                                   minSamplesLeaf = list(10),
+                                   mtries = list("sqrt"),
+                                   maxSamples = list(0.9),
+                                   classWeight = list(NULL))
+  
+  plpModel <- fitPlp(
+    trainData = reducedTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'RandomForest'
+  )
+  
+  expect_correct_fitPlp(plpModel, trainData)
+  
+})
+
+
+test_that('MLP fit works', {
+  modelSettings <- setMLP(
+    hiddenLayerSizes = list(c(20)),
+    alpha = list(1e-6),
+    maxIter = list(50),
+    epsilon = list(1e-08),
+    learningRateInit = list(0.01),
+    tol = list(1e-2) # reduce tol so I don't get convergence warnings
+  )
+  
+  plpModel <- fitPlp(
+    trainData = reducedTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'MLP'
+  )
+  
+  expect_correct_fitPlp(plpModel, trainData)
+})
+
+
+test_that('Naive bayes fit works', {
+  modelSettings <- setNaiveBayes()
+  
+  plpModel <- fitPlp(
+    trainData = reducedTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'Naive bayes'
+  )
+  
+  expect_correct_fitPlp(plpModel, trainData, outputRisk=FALSE) 
+  
+})
+
+
+test_that('Support vector machine fit works', {
+  modelSettings <- setSVM(C = list(1),
+                          degree = list(1),
+                          gamma = list('scale'),
+                          classWeight = list(NULL))
+  
+  plpModel <- fitPlp(
+    trainData = reducedTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'SVM'
+  )
+  
+  expect_correct_fitPlp(plpModel, trainData) 
+})

--- a/tests/testthat/test-sklearnClassifier.R
+++ b/tests/testthat/test-sklearnClassifier.R
@@ -72,6 +72,19 @@ test_that("check fit of DecisionTree", {
   
 })
 
+test_that('fitSklearn errors with wrong covariateData', {
+  
+  newTrainData <- copyTrainData(trainData)
+  class(newTrainData$covariateData) <- 'notCovariateData'
+  modelSettings <- setAdaBoost()
+  analysisId <- 42
+  
+  expect_error(fitSklearn(newTrainData,
+                          modelSettings,
+                          search='grid',
+                          analysisId))
+})
+
 
 test_that('AdaBoost fit works', {
   
@@ -165,4 +178,22 @@ test_that('Support vector machine fit works', {
   expect_correct_fitPlp(plpModel, trainData) 
   expect_equal(dir(plpModel$model),"model.pkl")
   
+})
+
+test_that('Sklearn predict works', {
+  
+  modelSettings <- setAdaBoost(nEstimators = list(10),
+                               learningRate = list(0.1),
+  )
+  
+  plpModel <- fitPlp(
+    trainData = tinyTrainData, 
+    modelSettings = modelSettings,
+    analysisId = 'Adaboost'
+  )
+  
+  predictions <- predictPythonSklearn(plpModel,
+                                      testData,
+                                      population)
+  expect_correct_predictions(predictions, testData)
 })

--- a/tests/testthat/test-sklearnClassifierSettings.R
+++ b/tests/testthat/test-sklearnClassifierSettings.R
@@ -26,7 +26,7 @@ test_that("setAdaBoost settings work checks", {
   inputs <- AdaBoostClassifierInputs(list, adset$param[[1]])
   expect_equal(
     names(inputs), 
-    c("base_estimator","n_estimators","learning_rate","algorithm","random_state" )
+    c("n_estimators","learning_rate","algorithm","random_state" )
     )
   
 })

--- a/tests/testthat/test-sklearnClassifierSettings.R
+++ b/tests/testthat/test-sklearnClassifierSettings.R
@@ -11,10 +11,9 @@ test_that("setAdaBoost settings work checks", {
   
   expect_equal(length(adset$param), 3*3*1)
   
-  expect_equal(unique(unlist(lapply(adset$param, function(x) x[[1]]))), NULL)
-  expect_equal(unique(unlist(lapply(adset$param, function(x) x[[2]]))), c(10,50, 200))
-  expect_equal(unique(unlist(lapply(adset$param, function(x) x[[3]]))), c(1, 0.5, 0.1))
-  expect_equal(unique(lapply(adset$param, function(x) x[[4]])), list('SAMME.R'))
+  expect_equal(unique(unlist(lapply(adset$param, function(x) x[[1]]))), c(10,50, 200))
+  expect_equal(unique(unlist(lapply(adset$param, function(x) x[[2]]))), c(1, 0.5, 0.1))
+  expect_equal(unique(lapply(adset$param, function(x) x[[3]])), list('SAMME.R'))
   
   expect_false(attr(adset$param, 'settings')$requiresDenseMatrix)
   expect_equal(attr(adset$param, 'settings')$name, 'AdaBoost')
@@ -40,10 +39,6 @@ test_that("setAdaBoost errors as expected", {
   expect_error(setAdaBoost(seed  =  list('seed')))
   
 })
-
-
-
-
 
 
 test_that("setMLP settings work checks", {
@@ -99,12 +94,6 @@ test_that("setMLP settings work checks", {
 })
 
 
-
-
-
-
-
-
 test_that("setNaiveBayes settings work checks", {
   
   nbset <- setNaiveBayes(
@@ -126,11 +115,6 @@ test_that("setNaiveBayes settings work checks", {
 })
 
 
-
-
-
-
-
 test_that("setRandomForest settings work checks", {
   
   rfset <- setRandomForest(
@@ -140,20 +124,20 @@ test_that("setRandomForest settings work checks", {
     minSamplesSplit = list(2,5),
     minSamplesLeaf = list(1,10),
     minWeightFractionLeaf = list(0),
-    mtries = list('auto', 'log2'),
+    mtries = list('sqrt', 'log2'),
     maxLeafNodes = list(NULL),
     minImpurityDecrease = list(0),
     bootstrap = list(TRUE),
     maxSamples = list(NULL, 0.9),
     oobScore = list(FALSE),
     nJobs = list(NULL),
-    classWeight = list('balanced_subsample', NULL),
+    classWeight = list(NULL),
     seed = sample(100000,1)
   )
   
   expect_equal(rfset$fitFunction, "fitSklearn")
   
-  expect_equal(length(rfset$param), 2*3*2*2*2*2*2)
+  expect_equal(length(rfset$param), 2*3*2*2*2*2*1)
   
   expect_equal(unique(lapply(rfset$param, function(x) x[[1]])), list(100,500))
   expect_equal(unique(unlist(lapply(rfset$param, function(x) x[[3]]))), c(4,10,17))
@@ -175,8 +159,6 @@ test_that("setRandomForest settings work checks", {
 })
 
 
-
-
 test_that("setSVM  settings work checks", {
   
   svmset <- setSVM (
@@ -187,14 +169,14 @@ test_that("setSVM  settings work checks", {
     coef0 = list(0.0),
     shrinking = list(TRUE), 
     tol = list(0.001),
-    classWeight = list('balanced', NULL), 
+    classWeight = list(NULL), 
     cacheSize  = 500,
     seed = sample(100000,1)
   )
   
   expect_equal(svmset$fitFunction, "fitSklearn")
   
-  expect_equal(length(svmset$param), 4*3*6*2)
+  expect_equal(length(svmset$param), 4*3*6*1)
   
   expect_equal(unique(lapply(svmset$param, function(x) x[[4]])), list('scale', 1e-04, 3e-05, 0.001, 0.01, 0.25))
   expect_equal(unique(unlist(lapply(svmset$param, function(x) x[[1]]))), c(1,0.9,2,0.1))


### PR DESCRIPTION
fixes #350 

Also changed a few things with sklearn models: 
- Removed 'balanced' option from default set of hyperparameters from various models. Various models used these to put more weight on the minority class when optimizing. In light of @cynthiayang525 work on class imbalance I think its reasonable to not include those in the defaults. This reduces the search space by a factor of 2x. For example random forest goes from about 200 runs to 100 for the default set. 
- Changed ```epsilon``` in the sklearn MLP to one value in the defaults. This is a parameter for numerical stability during optimization and doesn't make sense to include it in hyperparameter tuning (or even changing it really). This reduces the search space by a factor of 3x for the MLP.

I updated the tests:
- create ```tinyTrainData``` in ```helper-objects``` to fit sklearn models and KNN quickly. This data only has the ten features with highest coefficients when fitting LASSO.
- Add fits of Adaboost, RandomForest, SVM, MLP and Naive-Bayes to tests.
- Added ```expect_correct_fitPlp``` expectation to test output of fitPLP for different classifiers. This function is in ```helper-expectations```. Since I was running the same tests for all the sklearn classifiers I refactored it out for ease of maintenance.
- Removed instances of ```createTrainData``` from tests. Now ```trainData``` is created once in the helpers and when we need new trainData to test on it's copied (using a new function ```copyTrainData```).

I did test this locally on sklearn versions 1.2.0, 1.1.2 and 1.0.2 to make sure my changes were backwards compatible.