### PR TITLE
Making tests if table exists on server case-insensitive.

### DIFF
--- a/R/ImportFromCsv.R
+++ b/R/ImportFromCsv.R
@@ -60,12 +60,12 @@ insertCsvToDatabase <- function(
   }
   
   # check some plp tables exists in databaseSchemaSettings 
-  alltables <- DatabaseConnector::getTableNames(
+  alltables <- tolower(DatabaseConnector::getTableNames(
     connection = conn, 
     databaseSchema = databaseSchemaSettings$resultSchema
-  )
+  ))
   
-  if(!paste0(toupper(databaseSchemaSettings$tablePrefix),'PERFORMANCES') %in% alltables){
+  if(!tolower(paste0(databaseSchemaSettings$tablePrefix,'PERFORMANCES')) %in% alltables){
     ParallelLogger::logInfo(
       paste0(
         'performance table: ',paste0(toupper(databaseSchemaSettings$tablePrefix),'PERFORMANCES'),' not found, result database only contains ', 

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -134,7 +134,7 @@ insertResultsToSqlite <- function(
   conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
   on.exit(DatabaseConnector::disconnect(conn))
   
-  tablesExists <- sum(toupper(getPlpResultTables()) %in% toupper(DatabaseConnector::getTableNames(conn)))
+  tablesExists <- sum(tolower(getPlpResultTables()) %in% tolower(DatabaseConnector::getTableNames(conn)))
   tablesExists <- tablesExists == length(getPlpResultTables())
   
   if(!tablesExists){
@@ -941,13 +941,14 @@ deleteTables <- function(
 ){
   
   if(tablePrefix != ''){
-    tableNames <- paste0(toupper(gsub('_','',gsub(' ','', tablePrefix))), '_', tableNames)
+    tableNames <- tolower(paste0(gsub('_','',gsub(' ','', tablePrefix)), '_', tableNames))
   }
   
-  alltables <- DatabaseConnector::getTableNames(
+  alltables <- tolower(DatabaseConnector::getTableNames(
     connection = conn, 
     databaseSchema = databaseSchema
-  )
+  ))
+  
   
   for(tb in tableNames){
     if(tb %in% alltables){

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -107,9 +107,12 @@ test_that("database creation", {
     tablePrefix = appendRandom('test')
   )
   
-  tableNames <- DatabaseConnector::getTableNames(connection = conn, databaseSchema = ohdsiDatabaseSchema)
   # check the results table is created
-  testthat::expect_true(paste0(toupper(appendRandom('test')),'_PERFORMANCES') %in% tableNames)
+  testthat::expect_true(DatabaseConnector::existsTable(
+    connection = conn, 
+    databaseSchema = ohdsiDatabaseSchema,
+    tableName = paste0(appendRandom('test'),'_PERFORMANCES')
+  ))
 
 })
 
@@ -176,11 +179,13 @@ test_that("database deletion", {
     tablePrefix = appendRandom('test')
   )
   
-  tableNames <- DatabaseConnector::getTableNames(connection = conn, databaseSchema = ohdsiDatabaseSchema)
   # check the results table is then deleted
-  testthat::expect_false(paste0(toupper(appendRandom('test')),'_PERFORMANCES') %in% tableNames)
-  
-  
+  testthat::expect_false(DatabaseConnector::existsTable(
+    connection = conn, 
+    databaseSchema = ohdsiDatabaseSchema,
+    tableName = paste0(appendRandom('test'),'_PERFORMANCES')
+  ))
+
 })
 
 # disconnect


### PR DESCRIPTION
This PR solves an issue related to the upcoming DatabaseConnector 6.0.0: The getTableNames funtion will be changed to output in lowercase instead of uppercase for greater consistency across HADES (and to support dbplyr). Some code in PLP expects the output to be in uppercase. I've now made the checks case-insensitive, so it works both with the old and new versions of DatabaseConnector.

Note that I've based this PR on the main branch instead of develop. I was hoping this could be incorporated in a patch release, so the new DatabaseConnector version can be released soon.