### PR TITLE
Faster listCartesian

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,13 +60,11 @@ Suggests:
     pool,
     readr,
     ResourceSelection,
-    ResultModelManager,
     rmarkdown,
     RSQLite,
     scoring,
     shiny,
-    shinydashboard,
-    OhdsiShinyModules (>= 1.1.0),
+    OhdsiShinyModules (>= 1.0.0),
     survminer,
     testthat,
     withr,
@@ -77,7 +75,6 @@ Remotes:
     ohdsi/FeatureExtraction,
     ohdsi/IterativeHardThresholding,
     ohdsi/ParallelLogger,
-    ohdsi/OhdsiShinyModules@develop,
-    ohdsi/ResultModelManager@develop
-RoxygenNote: 7.2.1
+    ohdsi/OhdsiShinyModules
+RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Imports:
     PRROC,
     reticulate (> 1.16),
     rlang,
+    shinydashboard,
     SqlRender (>= 1.1.3),
     survival,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
 Imports:
     Andromeda,
     Cyclops (>= 3.0.0),
-    DatabaseConnector (>= 5.0.0),
+    DatabaseConnector (>= 6.0.0),
     dplyr,
     FeatureExtraction (>= 3.0.0),
     ggplot2,
@@ -78,6 +78,6 @@ Remotes:
     ohdsi/IterativeHardThresholding,
     ohdsi/ParallelLogger,
     ohdsi/OhdsiShinyModules@develop,
-    ohdsi/ResultModelManager
+    ohdsi/ResultModelManager@develop
 RoxygenNote: 7.2.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     RSQLite,
     scoring,
     shiny,
-    OhdsiShinyModules (>= 1.1.0),
+    OhdsiShinyModules (>= 1.0.2),
     survminer,
     testthat,
     withr,
@@ -76,7 +76,7 @@ Remotes:
     ohdsi/FeatureExtraction,
     ohdsi/IterativeHardThresholding,
     ohdsi/ParallelLogger,
-    ohdsi/OhdsiShinyModules@develop,
+    ohdsi/OhdsiShinyModules,
     ohdsi/ResultModelManager
 RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
 Imports:
     Andromeda,
     Cyclops (>= 3.0.0),
-    DatabaseConnector (>= 6.0.0),
+    DatabaseConnector (>= 5.0.0),
     dplyr,
     FeatureExtraction (>= 3.0.0),
     ggplot2,
@@ -60,11 +60,12 @@ Suggests:
     pool,
     readr,
     ResourceSelection,
+    ResultModelManager,
     rmarkdown,
     RSQLite,
     scoring,
     shiny,
-    OhdsiShinyModules (>= 1.0.0),
+    OhdsiShinyModules (>= 1.1.0),
     survminer,
     testthat,
     withr,
@@ -75,6 +76,7 @@ Remotes:
     ohdsi/FeatureExtraction,
     ohdsi/IterativeHardThresholding,
     ohdsi/ParallelLogger,
-    ohdsi/OhdsiShinyModules
+    ohdsi/OhdsiShinyModules@develop,
+    ohdsi/ResultModelManager
 RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/R/SklearnClassifierHelpers.R
+++ b/R/SklearnClassifierHelpers.R
@@ -23,24 +23,10 @@
 #' @param allList a list of lists
 #' @return A list with all possible combinations from the input list of lists
 #' @export
-listCartesian <- function(allList){
-  
-  sizes <- lapply(allList, function(x) 1:length(x))
-  combinations <- expand.grid(sizes)
-  
-  result <- list()
-  length(result) <- nrow(combinations)
-  
-  for(i in 1:nrow(combinations)){
-    tempList <- list()
-    for(j in 1:ncol(combinations)){
-      tempList <- c(tempList, list(allList[[j]][[combinations[i,j]]]))
-    }
-    names(tempList) <- names(allList)
-    result[[i]] <- tempList
-  }
-  
-  return(result)
+listCartesian <- function(allList) {
+  combinations <- expand.grid(allList)
+  results <- lapply(seq_len(nrow(combinations)),
+                    function(i) lapply(combinations, "[", i))
+  return(results)
 }
-
   

--- a/R/SklearnClassifierHelpers.R
+++ b/R/SklearnClassifierHelpers.R
@@ -26,7 +26,7 @@
 listCartesian <- function(allList) {
   combinations <- expand.grid(allList)
   results <- lapply(seq_len(nrow(combinations)),
-                    function(i) sapply(combinations, "[", i))
+                    function(i) lapply(combinations, function(x) x[i][[1]]))
   return(results)
 }
   

--- a/R/SklearnClassifierHelpers.R
+++ b/R/SklearnClassifierHelpers.R
@@ -26,7 +26,7 @@
 listCartesian <- function(allList) {
   combinations <- expand.grid(allList)
   results <- lapply(seq_len(nrow(combinations)),
-                    function(i) lapply(combinations, "[", i))
+                    function(i) sapply(combinations, "[", i))
   return(results)
 }
   


### PR DESCRIPTION
@jreps , I made a faster version of listCartesian. This is used when enumerating the hyperparameter space for the models. For some of the deep learning models in deepPLP this was taking an annoyingly long time (even up to many minutes). So I rewrote the function for a 10x speedup.

Note I had to add shinydashboards to the DESCRIPTION to get the R check to pass. I assume that's related to your shiny app development.