### PR TITLE
move loadPlpData in runMultiple to save loading until later

### DIFF
--- a/R/RunMultiplePlp.R
+++ b/R/RunMultiplePlp.R
@@ -132,11 +132,10 @@ runMultiplePlp <- function(
       dataExists <- length(dir(file.path(saveDirectory, settings$dataLocation)))>0
       
       if(dataExists){
-        plpData <- PatientLevelPrediction::loadPlpData(file.path(saveDirectory, settings$dataLocation))
-        
         analysisExists <- file.exists(file.path(saveDirectory, settings$analysisId,'diagnosePlp.rds'))
         
         if(!analysisExists){
+          plpData <- PatientLevelPrediction::loadPlpData(file.path(saveDirectory, settings$dataLocation))
           diagnosePlpSettings <- list(
             plpData = plpData,
             outcomeId = modelDesign$outcomeId,
@@ -171,11 +170,10 @@ runMultiplePlp <- function(
       dataExists <- length(dir(file.path(saveDirectory, settings$dataLocation)))>0
       
       if(dataExists){
-        plpData <- PatientLevelPrediction::loadPlpData(file.path(saveDirectory, settings$dataLocation))
-        
         analysisExists <- file.exists(file.path(saveDirectory, settings$analysisId,'plpResult', 'runPlp.rds'))
+        
         if(!analysisExists){
-          
+          plpData <- PatientLevelPrediction::loadPlpData(file.path(saveDirectory, settings$dataLocation))
           runPlpSettings <- list(
             plpData = plpData,
             outcomeId = modelDesign$outcomeId,


### PR DESCRIPTION
A very small change that moves the loading of PLP data (if it already exists) slightly to save loading it when analysis exist as well. Found it useful when running strategus multiple times.

All tests passed locally on ubuntu.