### PR TITLE
406 hades weekly fail - hotfix

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -22,7 +22,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}  # Does not appear to have Java 32-bit, hence the --no-multiarch
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-22.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"}
 
     env:
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "22.04"))')
           
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -65,10 +65,10 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
           
-      - name: Tell windows about miniconda
-        shell: bash
-        run: |
-          echo "C:\Miniconda\bin" >> $GITHUB_PATH
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: "r-reticulate"
         
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -64,6 +64,8 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          
+      - name: Tell windows about miniconda
         if: runner.os == 'Windows'
         run: Add-Content $env:PATH "C:\Miniconda"
         

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -66,8 +66,9 @@ jobs:
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
           
       - name: Tell windows about miniconda
-        if: runner.os == 'Windows'
-        run: Add-Content $env:PATH "C:\Miniconda"
+        shell: bash
+        run: |
+          echo "C:\Miniconda" >> $GITHUB_PATH
         
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -64,6 +64,8 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+        if: runner.os == 'Windows'
+        run: Add-Content $env:PATH "C:\Miniconda"
         
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -46,20 +46,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-    
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: "3.7"
-          activate-environment: r-reticulate
-      
-      - name: python main dependencies  
-        run: conda install --name r-reticulate numpy scipy scikit-learn pandas pydotplus joblib
-      
-      - name: python json dependencies  
-        run: conda install --name r-reticulate -c conda-forge sklearn-json 
-      
-      - name: python scikit-survival dependencies    
-        run: conda install --name r-reticulate -c sebp scikit-survival
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -83,11 +69,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          
-      - name: use r-reticulate environment
-        run: |
-          reticulate::use_condaenv("r-reticulate", required = TRUE)
-        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Tell windows about miniconda
         shell: bash
         run: |
-          echo "C:\Miniconda" >> $GITHUB_PATH
+          echo "C:\Miniconda\bin" >> $GITHUB_PATH
         
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -51,9 +51,9 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-tinytex@v1
+      - uses: r-lib/actions/setup-tinytex@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install system requirements
         if: runner.os == 'Linux'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: PatientLevelPrediction
 Type: Package
 Title: Developing patient level prediction using data in the OMOP Common Data
     Model
-Version: 6.3.4
+Version: 6.3.5
 Date: 2023-08-15
 Authors@R: c(
     person("Jenna", "Reps", email = "jreps@its.jnj.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+PatientLevelPrediction 6.3.5
+======================
+- Fix sklearnToJson to be compatible with scikit-learn>=1.3
+- Fix github actions so it's not hardcoded to use python 3.7
+
+
 PatientLevelPrediction 6.3.4
 ======================
 - added spline feature engineering 

--- a/R/SklearnToJson.R
+++ b/R/SklearnToJson.R
@@ -89,7 +89,11 @@ deSerializeTree <- function(tree_dict, nFeatures, nClasses, nOutputs) {
                             reticulate::tuple(reticulate::py_to_r(tree_dict["nodes"][i])))
   }
   
-  names = list("left_child", "right_child", "feature", "threshold", "impurity", "n_node_samples", "weighted_n_node_samples")
+  names <- list("left_child", "right_child", "feature", "threshold", "impurity", "n_node_samples", "weighted_n_node_samples")
+  if (length(tree_dict["nodes"][0])==8) {
+    # model used sklearn>=1.3 which added a parameter
+    names[[8]] <- "missing_go_to_left"
+  }
   
   sklearn <- reticulate::import("sklearn")
   np <- reticulate::import("numpy", convert = FALSE)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ System Requirements
 Requires R (version 4.0 or higher). Installation on Windows requires [RTools](http://cran.r-project.org/bin/windows/Rtools/). Libraries used in PatientLevelPrediction require Java and Python.
 
 The python installation is required for some of the machine learning algorithms. We advise to
-install Python 3.7 using Anaconda (https://www.continuum.io/downloads). 
+install Python 3.8 or higher using Anaconda (https://www.continuum.io/downloads). 
 
 Getting Started
 ===============


### PR DESCRIPTION
Fixes #406 

The issue was that in `scikit-learn 1.3` they added a new feature to decision trees to deal with missing data. This broke our serialization of `scikit-learn` models to json. The reason this was not detected in our regular tests but in the weekly Hades tests is that there was inconsistency in how python environments were set up for testing. It was hardcoded in our regular test github actions to use `python 3.7`, which has gone out of support. This resulted in our tests using an older version of `scikit-learn` which didn't have this issue.

In this PR I've 
- Fixed the serialization of trees so they work both with `scikit-learn 1.3` and older versions.
- Simplified the actions so the setup of python env uses `configurePython` function for consistency
- Update ubuntu runner to use `22.04` which is the latest long-term supported release. This was necessary since otherwise a system library needed to be updated for `scipy` to work correctly in `python 3.11`
- Update README to mention currently supported python versions 3.8 and newer are supported

Now the tests test against the default python version in `conda`, which at this moment is `python 3.11`.  Other option would be to hardcode somehere a different python version to test against. But I'd expect versions `3.8-3.11` to work currently. 

@jreps could you review/approve this? 