### PR TITLE
413 python fix

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -67,8 +67,6 @@ jobs:
           
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: "r-reticulate"
         
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/HelperFunctions.R
+++ b/R/HelperFunctions.R
@@ -94,9 +94,10 @@ listAppend <- function(a, b){
 #'
 #' @param envname   A string for the name of the virtual environment (default is 'PLP') 
 #' @param envtype   An option for specifying the environment as'conda' or 'python'.  If NULL then the default is 'conda' for windows users and 'python' for non-windows users 
+#' @param condaPythonVersion String, Python version to use when creating a conda environment
 #'
 #' @export
-configurePython <- function(envname='PLP', envtype=NULL){
+configurePython <- function(envname='PLP', envtype=NULL, condaPythonVersion="3.11"){
   
   if(is.null(envtype)){
     if(getOs()=='windows'){
@@ -113,7 +114,7 @@ configurePython <- function(envname='PLP', envtype=NULL){
       warning(paste0('Conda environment ', envname,' exists.  You can use reticulate::conda_remove() to remove if you want to fresh config'))
     } else {
       ParallelLogger::logInfo(paste0('Creating virtual conda environment called ', envname))
-      location <- reticulate::conda_create(envname=envname, packages = "python", conda = "auto")
+      location <- reticulate::conda_create(envname=envname, packages = paste0("python==", condaPythonVersion), conda = "auto")
     }
     packages <- c('numpy','scipy','scikit-learn', 'pandas','pydotplus','joblib')
     ParallelLogger::logInfo(paste0('Adding python dependancies to ', envname))

--- a/man/configurePython.Rd
+++ b/man/configurePython.Rd
@@ -4,12 +4,14 @@
 \alias{configurePython}
 \title{Sets up a virtual environment to use for PLP (can be conda or python)}
 \usage{
-configurePython(envname = "PLP", envtype = NULL)
+configurePython(envname = "PLP", envtype = NULL, condaPythonVersion = "3.11")
 }
 \arguments{
 \item{envname}{A string for the name of the virtual environment (default is 'PLP')}
 
 \item{envtype}{An option for specifying the environment as'conda' or 'python'.  If NULL then the default is 'conda' for windows users and 'python' for non-windows users}
+
+\item{condaPythonVersion}{String, Python version to use when creating a conda environment}
 }
 \description{
 Sets up a virtual environment to use for PLP (can be conda or python)


### PR DESCRIPTION
Hi @jreps ,

This is a fix for a python issue which was causing tests to fail. After this fix tests on windows and ubuntu should pass, while tests on macOS are still failing because of the vroom issue that's affecting many.

I've now set as a default python version 3.11 when creating a new conda environment using the `configurePython` function. 