### PR TITLE
only restict to first if many observations per subjectId

### DIFF
--- a/R/PopulationSettings.R
+++ b/R/PopulationSettings.R
@@ -294,10 +294,12 @@ createStudyPopulation <- function(
   if (firstExposureOnly) {
     ParallelLogger::logTrace(paste("Restricting to first exposure"))
     
-    population <- population %>%
-      dplyr::arrange(.data$subjectId,.data$cohortStartDate) %>%
-      dplyr::group_by(.data$subjectId) %>%
-      dplyr::filter(dplyr::row_number(.data$subjectId)==1)
+    if (nrow(population) > dplyr::n_distinct(population$subjectId)) {
+      population <- population %>%
+        dplyr::arrange(.data$subjectId,.data$cohortStartDate) %>%
+        dplyr::group_by(.data$subjectId) %>%
+        dplyr::filter(dplyr::row_number(.data$subjectId)==1)
+    }
     
     attrRow <- population %>% dplyr::group_by() %>%
       dplyr::summarise(outcomeId = get('oId'),


### PR DESCRIPTION
@jreps 

When we create our `population` with `firstExposureOnly` set to `TRUE there is a very expensive [group_by](https://github.com/OHDSI/PatientLevelPrediction/blob/main/R/PopulationSettings.R#L297) operation done:

```R 
population <- population %>%
    dplyr::arrange(.data$subjectId,.data$cohortStartDate) %>%
    dplyr::group_by(.data$subjectId) %>%
    dplyr::filter(dplyr::row_number(.data$subjectId)==1)
```
The amount of groups is equal to amount of subjects, so possibly millions. 

When there is only one observation per `subjectId` this is a no-op and can be skipped. 

In this PR I've added a condition:

```R
(nrow(population) > dplyr::n_distinct(population$subjectId))
```
If rows in population are more than amount of subjects (aka more observations than subjects), then and only then we do this expensive operation. 

This took the population generation time down from about 1.4 minutes to 0.8 seconds for a cohort of about 460k. 

