### PR TITLE
Fix logger for external validation

### DIFF
--- a/R/ExternalValidatePlp.R
+++ b/R/ExternalValidatePlp.R
@@ -445,7 +445,6 @@ validateExternal <- function(validationDesignList,
       logSettings$logFileName <- 'validationLog'
       logger <- do.call(createLog, logSettings)
       ParallelLogger::registerLogger(logger)
-      on.exit(closeLog(logger))
       
       ParallelLogger::logInfo(paste('Validating model on', database$cdmDatabaseName))
       
@@ -529,6 +528,7 @@ validateExternal <- function(validationDesignList,
         )
         analysisInfo[[databaseName]] <<- analysisInfo[[databaseName]] + 1
       })
+      on.exit(closeLog(logger))
     }
   }
   for (database in databaseDetails) {

--- a/R/ExternalValidatePlp.R
+++ b/R/ExternalValidatePlp.R
@@ -435,16 +435,18 @@ validateExternal <- function(validationDesignList,
   for (name in databaseNames) {
     analysisInfo[name] <- 1
   }
+  
+  # initiate log
+  logSettings$saveDirectory <- outputFolder
+  logSettings$logFileName <- 'validationLog'
+  logger <- do.call(createLog, logSettings)
+  ParallelLogger::registerLogger(logger)
+  on.exit(closeLog(logger))
+  
   results <- NULL
   for (design in validationDesignList) {
     for (database in databaseDetails) {
       databaseName <- database$cdmDatabaseName
-      # initiate log
-      logSettings$saveDirectory <- file.path(outputFolder,
-                                             database$cdmDatabaseName)
-      logSettings$logFileName <- 'validationLog'
-      logger <- do.call(createLog, logSettings)
-      ParallelLogger::registerLogger(logger)
       
       ParallelLogger::logInfo(paste('Validating model on', database$cdmDatabaseName))
       
@@ -528,7 +530,6 @@ validateExternal <- function(validationDesignList,
         )
         analysisInfo[[databaseName]] <<- analysisInfo[[databaseName]] + 1
       })
-      on.exit(closeLog(logger))
     }
   }
   for (database in databaseDetails) {


### PR DESCRIPTION
It was created multiple time (inside the nested for loop) and only closed when exiting the function. This resulted in multiple duplicate lines being logged in the file.