### PR TITLE
Changes required for the upcoming Andromeda 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ VignetteBuilder: knitr
 Depends:
     R (>= 4.0.0)
 Imports:
-    Andromeda (>= 1.0.0),
+    Andromeda,
     Cyclops (>= 3.0.0),
     DatabaseConnector (>= 6.0.0),
     digest,
@@ -63,8 +63,5 @@ Suggests:
     withr,
     xgboost (> 1.3.2.1),
     lightgbm
-Remotes:
-  ohdsi/Andromeda@develop,
-  ohdsi/FeatureExtraction
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,7 @@ Suggests:
     xgboost (> 1.3.2.1),
     lightgbm
 Remotes:
-  ohdsi/Andromeda@develop
+  ohdsi/Andromeda@develop,
+  ohdsi/FeatureExtraction
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ VignetteBuilder: knitr
 Depends:
     R (>= 4.0.0)
 Imports:
-    Andromeda,
+    Andromeda (>= 1.0.0),
     Cyclops (>= 3.0.0),
     DatabaseConnector (>= 6.0.0),
     digest,
@@ -63,5 +63,7 @@ Suggests:
     withr,
     xgboost (> 1.3.2.1),
     lightgbm
+Remotes:
+  ohdsi/Andromeda@develop
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -281,11 +281,11 @@ dataSummary <- function(data) {
 
 
   result <- data$Train$covariateData$covariates %>%
-    dplyr::group_by(.data$covariateId) %>%
-    dplyr::summarise(N = length(.data$covariateValue)) %>%
-    dplyr::collect()
+    dplyr::distinct(.data$covariateId) %>%
+    dplyr::count() %>%
+    dplyr::pull()
 
-  ParallelLogger::logInfo(paste0(nrow(result), " covariates in train data"))
+  ParallelLogger::logInfo(paste0(result, " covariates in train data"))
 
   if ("Test" %in% names(data)) {
     ParallelLogger::logInfo("Test Set:")

--- a/R/Formatting.R
+++ b/R/Formatting.R
@@ -147,6 +147,7 @@ MapIds <- function(
       covariateId = covariateData$covariates %>%
         dplyr::inner_join(covariateData$rowMap, by = "rowId") %>% # first restrict the covariates to the rowMap$rowId
         dplyr::distinct(.data$covariateId) %>%
+        dplyr::arrange(.data$covariateId) %>%
         dplyr::pull()
     )
     mapping$columnId <- 1:nrow(mapping)

--- a/tests/testthat/test-formatting.R
+++ b/tests/testthat/test-formatting.R
@@ -142,7 +142,7 @@ test_that("toSparseM", {
   sparseMat.test <- toSparseM(FplpData, Fpopulation, map = NULL)
   matrix.real <- matrix(rep(0, 5 * 7), ncol = 7)
   x <- c(1, 1, 1, 3, 3, 3, 5, 5)
-  y <- c(1, 2, 3, 2, 4, 5, 6, 7)
+  y <- c(5, 6, 7, 1, 2, 7, 3, 4)
   for (a in 1:8) matrix.real[x[a], y[a]] <- 1
   expect_that(as.matrix(sparseMat.test$dataMatrix), is_equivalent_to(matrix.real))
 


### PR DESCRIPTION
The new upcoming Andromeda version will switch to a DuckDB backend. Running the unit tests I found these two changes that need to be made. 

This new version should work with both the new and old version of Andromeda.

Note that the sparse matrix unit test required the covariate IDs be in the same order as they were inserted in Andromeda, but DuckDb does not maintain ordering, so I'm now sorting by covariateId instead, and changed the unit test.