### PR TITLE
two upload bugs

### DIFF
--- a/R/uploadToDatabaseModelDesign.R
+++ b/R/uploadToDatabaseModelDesign.R
@@ -100,7 +100,8 @@ insertModelDesignSettings <- function(
     resultSchema = databaseSchemaSettings$cohortDefinitionSchema,
     targetDialect = databaseSchemaSettings$targetDialect,
     cohortDefinition = getCohortDef(cohortDefinitions, object$targetId),
-    tablePrefix = databaseSchemaSettings$tablePrefixCohortDefinitionTables,
+    cgTablePrefix = databaseSchemaSettings$tablePrefixCohortDefinitionTables,
+    plpTablePrefix = databaseSchemaSettings$tablePrefix,
     tempEmulationSchema = databaseSchemaSettings$tempEmulationSchema
   )
   ParallelLogger::logInfo(paste0("tId: ", tId))
@@ -110,7 +111,8 @@ insertModelDesignSettings <- function(
     resultSchema = databaseSchemaSettings$cohortDefinitionSchema,
     targetDialect = databaseSchemaSettings$targetDialect,
     cohortDefinition = getCohortDef(cohortDefinitions, object$outcomeId),
-    tablePrefix = databaseSchemaSettings$tablePrefixCohortDefinitionTables,
+    cgTablePrefix = databaseSchemaSettings$tablePrefixCohortDefinitionTables,
+    plpTablePrefix = databaseSchemaSettings$tablePrefix,
     tempEmulationSchema = databaseSchemaSettings$tempEmulationSchema
   )
   ParallelLogger::logInfo(paste0("oId: ", oId))


### PR DESCRIPTION
- fixing bug where the cohort_definition and cohort tables were forced to use the same prefix when uploading results
- fixing issue where duplicate cohort_definition rows caused errors

[this pull request fixes the issue 542 we ran into when uploading results with the same cohorts in parallel - not a common error as this is probably very rarely done and you have to be unlucky that the same cohort is being inserted at the same time across parallel runs. It simply restricts to the first row if there are multiple rows returned for a cohort/setting.  In the future, we may want to look at better ways to handle inserts for the same cohort/setting being done at the same time.]