### PR TITLE
Issue 549

### DIFF
--- a/R/ExistingSklearn.R
+++ b/R/ExistingSklearn.R
@@ -91,7 +91,6 @@ createSklearnModel <- function(
   checkIsClass(restrictPlpDataSettings , c("NULL", "restrictPlpDataSettings"))
   checkIsClass(covariateSettings, c("list", "NULL", "covariateSettings"))
   
-  #checkIsClass(FeatureEngineering, c("list", "NULL"))
   checkIsClass(requireDenseMatrix, c("logical"))
   
   # start to make the plpModel
@@ -112,17 +111,16 @@ createSklearnModel <- function(
     modelDesign = PatientLevelPrediction::createModelDesign(
       targetId = targetId,
       outcomeId = outcomeId,
-      restrictPlpDataSettings = restrictPlpDataSettings,
+      modelSettings = existingModel,
       covariateSettings = covariateSettings,
       populationSettings = populationSettings,
-      sampleSettings = PatientLevelPrediction::createSampleSettings(), # need this?
+      restrictPlpDataSettings = restrictPlpDataSettings,
       preprocessSettings = PatientLevelPrediction::createPreprocessSettings(
         minFraction = 0,
         normalize = FALSE,
         removeRedundancy = FALSE
       ),
-      modelSettings = existingModel,
-      splitSettings = PatientLevelPrediction::createDefaultSplitSetting()
+      splitSettings = PatientLevelPrediction::createDefaultSplitSetting(splitSeed = 123)
     ),
     model = modelLocation,
     trainDetails = list(

--- a/R/Glm.R
+++ b/R/Glm.R
@@ -35,7 +35,7 @@
 #' @param populationSettings Add development population settings
 #' @param restrictPlpDataSettings Add development restriction settings
 #' @param covariateSettings Add the covariate settings here to specify how the model covariates are created from the OMOP CDM
-#' @param FeatureEngineering Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+#' @param featureEngineering Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
 #'   This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that 
 #'   function. funct must take as input trainData (a plpData object) and settings (a list).
 #' @param tidyCovariates Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)

--- a/R/Glm.R
+++ b/R/Glm.R
@@ -30,6 +30,17 @@
 #' linear predictors to outcome probabilities. For generalized linear models
 #' this is the inverse of the link function. Supported values is only
 #' "logistic" for logistic regression model at the moment. 
+#' @param targetId Add the development targetId here
+#' @param outcomeId Add the development outcomeId here
+#' @param populationSettings Add development population settings
+#' @param restrictPlpDataSettings Add development restriction settings
+#' @param covariateSettings Add the covariate settings here to specify how the model covariates are created from the OMOP CDM
+#' @param FeatureEngineering Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+#'   This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that 
+#'   function. funct must take as input trainData (a plpData object) and settings (a list).
+#' @param tidyCovariates Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)
+#' @param requireDenseMatrix Specify whether the model needs a dense matrix (TRUE or FALSE)
+#' 
 #' @return A model object containing the model (Coefficients and intercept)
 #' and the prediction function.
 #' @examples
@@ -43,17 +54,37 @@
 #' # see the predicted risk values
 #' prediction$value
 #' @export
-createGlmModel <- function(coefficients,
-                           intercept = 0,
-                           mapping = "logistic") {
-
+createGlmModel <- function(
+    coefficients,
+    intercept = 0,
+    mapping = "logistic",
+    targetId = NULL,
+    outcomeId = NULL,
+    populationSettings = createStudyPopulationSettings(),
+    restrictPlpDataSettings = createRestrictPlpDataSettings(),
+    covariateSettings = FeatureExtraction::createDefaultCovariateSettings(),
+    featureEngineering = NULL,
+    tidyCovariates = NULL,
+    requireDenseMatrix = FALSE
+) {
+  
   checkDataframe(coefficients, 
     c("covariateId", "coefficient"), 
     c("numeric", "numeric"))
   checkHigherEqual(coefficients$covariateId, 0)
   checkIsClass(intercept, c("numeric"))
-  checkIsClass(mapping, c("character"))
-  checkIsEqual(mapping, "logistic")
+  checkIsClass(mapping, c("character", "function"))
+  #checkIsEqual(mapping, "logistic")
+  
+  checkIsClass(targetId, c("numeric", "NULL"))
+  checkIsClass(outcomeId, c("numeric", "NULL"))
+  
+  checkIsClass(populationSettings, c("NULL", "populationSettings"))
+  checkIsClass(restrictPlpDataSettings , c("NULL", "restrictPlpDataSettings"))
+  checkIsClass(covariateSettings, c("list", "NULL", "covariateSettings"))
+  
+  #checkIsClass(FeatureEngineering, c("list", "NULL"))
+  checkIsClass(requireDenseMatrix, c("logical"))
 
   model <- list(
     intercept = intercept,
@@ -65,21 +96,25 @@ createGlmModel <- function(coefficients,
   class(existingModel) <- "modelSettings"
 
   plpModel <- list(
-    preprocessing = list(
-      tidyCovariates = NULL,
-      requireDenseMatrix = FALSE
+    preprocessing = preprocessing <- list(
+      featureEngineering = featureEngineering,
+      tidyCovariates = tidyCovariates,
+      requireDenseMatrix = requireDenseMatrix
     ),
     covariateImportance = NULL,
     modelDesign = PatientLevelPrediction::createModelDesign(
-      targetId = NULL,
-      outcomeId = NULL,
-      modelSettings = existingModel
+      targetId = targetId,
+      outcomeId = outcomeId,
+      modelSettings = existingModel,
+      covariateSettings = covariateSettings, 
+      populationSettings = populationSettings,
+      restrictPlpDataSettings = restrictPlpDataSettings
     ),
     model = model,
     trainDetails = NULL
   )
   attr(plpModel, "modelType") <- "binary"
-  attr(plpModel, "saveType") <- "RToJson"
+  attr(plpModel, "saveType") <- "RtoJson"
   attr(plpModel, "predictionFunction") <- "PatientLevelPrediction::predictGlm"
   class(plpModel) <- "plpModel"
   return(plpModel)
@@ -139,6 +174,17 @@ predictGlm <- function(plpModel, data, cohort) {
     prediction$value <- prediction$value^2
   } else if (plpModel$model$mapping == "exponential") {
     prediction$value <- exp(prediction$value)
+  } else if(inherits(plpModel$model$mapping, "character")){
+    # if some other character try and convert it to a function
+    message('Creating mapping function from function name')
+    mapFun <- eval(parse(text = plpModel$model$mapping))
+    message('Applying mapping function')
+    prediction$value <- mapFun(prediction$value)
+  } else if(inherits(plpModel$model$mapping, "function")){
+    message('Applying mapping function')
+    prediction$value <- plpModel$model$mapping(prediction$value)
+  } else{
+    message('No mapping applied due to invalid mapping')
   }
   
   attr(prediction, "metaData")$modelType <- "binary"

--- a/R/Glm.R
+++ b/R/Glm.R
@@ -32,7 +32,7 @@
 #' "logistic" for logistic regression model at the moment. 
 #' @param targetId Add the development targetId here
 #' @param outcomeId Add the development outcomeId here
-#' @param populationSettings Add development population settings
+#' @param populationSettings Add development population settings (this includes the time-at-risk settings).
 #' @param restrictPlpDataSettings Add development restriction settings
 #' @param covariateSettings Add the covariate settings here to specify how the model covariates are created from the OMOP CDM
 #' @param featureEngineering Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
@@ -96,12 +96,16 @@ createGlmModel <- function(
   class(existingModel) <- "modelSettings"
 
   plpModel <- list(
-    preprocessing = preprocessing <- list(
+    preprocessing = list(
       featureEngineering = featureEngineering,
       tidyCovariates = tidyCovariates,
       requireDenseMatrix = requireDenseMatrix
     ),
-    covariateImportance = NULL,
+    covariateImportance = data.frame(
+      covariateId = coefficients$covariateId,
+      covariateValue = coefficients$coefficient,
+      included = TRUE
+    ),
     modelDesign = PatientLevelPrediction::createModelDesign(
       targetId = targetId,
       outcomeId = outcomeId,

--- a/man/createGlmModel.Rd
+++ b/man/createGlmModel.Rd
@@ -4,7 +4,19 @@
 \alias{createGlmModel}
 \title{createGlmModel}
 \usage{
-createGlmModel(coefficients, intercept = 0, mapping = "logistic")
+createGlmModel(
+  coefficients,
+  intercept = 0,
+  mapping = "logistic",
+  targetId = NULL,
+  outcomeId = NULL,
+  populationSettings = createStudyPopulationSettings(),
+  restrictPlpDataSettings = createRestrictPlpDataSettings(),
+  covariateSettings = FeatureExtraction::createDefaultCovariateSettings(),
+  FeatureEngineering = NULL,
+  tidyCovariates = NULL,
+  requireDenseMatrix = FALSE
+)
 }
 \arguments{
 \item{coefficients}{A dataframe containing two columns, coefficients and
@@ -18,6 +30,24 @@ package.}
 linear predictors to outcome probabilities. For generalized linear models
 this is the inverse of the link function. Supported values is only
 "logistic" for logistic regression model at the moment.}
+
+\item{targetId}{Add the development targetId here}
+
+\item{outcomeId}{Add the development outcomeId here}
+
+\item{populationSettings}{Add development population settings}
+
+\item{restrictPlpDataSettings}{Add development restriction settings}
+
+\item{covariateSettings}{Add the covariate settings here to specify how the model covariates are created from the OMOP CDM}
+
+\item{FeatureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
+function. funct must take as input trainData (a plpData object) and settings (a list).}
+
+\item{tidyCovariates}{Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)}
+
+\item{requireDenseMatrix}{Specify whether the model needs a dense matrix (TRUE or FALSE)}
 }
 \value{
 A model object containing the model (Coefficients and intercept)

--- a/man/createGlmModel.Rd
+++ b/man/createGlmModel.Rd
@@ -35,7 +35,7 @@ this is the inverse of the link function. Supported values is only
 
 \item{outcomeId}{Add the development outcomeId here}
 
-\item{populationSettings}{Add development population settings}
+\item{populationSettings}{Add development population settings (this includes the time-at-risk settings).}
 
 \item{restrictPlpDataSettings}{Add development restriction settings}
 

--- a/man/createGlmModel.Rd
+++ b/man/createGlmModel.Rd
@@ -13,7 +13,7 @@ createGlmModel(
   populationSettings = createStudyPopulationSettings(),
   restrictPlpDataSettings = createRestrictPlpDataSettings(),
   covariateSettings = FeatureExtraction::createDefaultCovariateSettings(),
-  FeatureEngineering = NULL,
+  featureEngineering = NULL,
   tidyCovariates = NULL,
   requireDenseMatrix = FALSE
 )
@@ -41,13 +41,13 @@ this is the inverse of the link function. Supported values is only
 
 \item{covariateSettings}{Add the covariate settings here to specify how the model covariates are created from the OMOP CDM}
 
-\item{FeatureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
-This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
-function. funct must take as input trainData (a plpData object) and settings (a list).}
-
 \item{tidyCovariates}{Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)}
 
 \item{requireDenseMatrix}{Specify whether the model needs a dense matrix (TRUE or FALSE)}
+
+\item{FeatureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
+function. funct must take as input trainData (a plpData object) and settings (a list).}
 }
 \value{
 A model object containing the model (Coefficients and intercept)

--- a/man/createGlmModel.Rd
+++ b/man/createGlmModel.Rd
@@ -41,13 +41,13 @@ this is the inverse of the link function. Supported values is only
 
 \item{covariateSettings}{Add the covariate settings here to specify how the model covariates are created from the OMOP CDM}
 
+\item{featureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
+function. funct must take as input trainData (a plpData object) and settings (a list).}
+
 \item{tidyCovariates}{Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)}
 
 \item{requireDenseMatrix}{Specify whether the model needs a dense matrix (TRUE or FALSE)}
-
-\item{FeatureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
-This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
-function. funct must take as input trainData (a plpData object) and settings (a list).}
 }
 \value{
 A model object containing the model (Coefficients and intercept)

--- a/man/createSklearnModel.Rd
+++ b/man/createSklearnModel.Rd
@@ -8,9 +8,15 @@ PLP framework}
 createSklearnModel(
   modelLocation = "/model",
   covariateMap = data.frame(columnId = 1:2, covariateId = c(1, 2), ),
-  covariateSettings,
-  populationSettings,
-  isPickle = TRUE
+  isPickle = TRUE,
+  targetId = NULL,
+  outcomeId = NULL,
+  populationSettings = createStudyPopulationSettings(),
+  restrictPlpDataSettings = createRestrictPlpDataSettings(),
+  covariateSettings = FeatureExtraction::createDefaultCovariateSettings(),
+  featureEngineering = NULL,
+  tidyCovariates = NULL,
+  requireDenseMatrix = FALSE
 )
 }
 \arguments{
@@ -24,13 +30,26 @@ For example, if you had a column called 'age' in your model and this was the
 3rd column when fitting the model, then the values for columnId would be 3,
 covariateId would be 1002 (the covariateId for age in years) and}
 
-\item{covariateSettings}{The settings for the standardized covariates}
-
-\item{populationSettings}{The settings for the population, this includes the
-time-at-risk settings and inclusion criteria.}
-
 \item{isPickle}{If the model should be saved as a pickle set this to TRUE if
 it should be saved as json set this to FALSE.}
+
+\item{targetId}{Add the development targetId here}
+
+\item{outcomeId}{Add the development outcomeId here}
+
+\item{populationSettings}{Add development population settings (this includes the time-at-risk settings).}
+
+\item{restrictPlpDataSettings}{Add development restriction settings}
+
+\item{covariateSettings}{Add the covariate settings here to specify how the model covariates are created from the OMOP CDM}
+
+\item{featureEngineering}{Add any feature engineering here (e.g., if you need to modify the covariates before applying the model)
+This is a list of lists containing a string named funct specifying the engineering function to call and settings that are inputs to that
+function. funct must take as input trainData (a plpData object) and settings (a list).}
+
+\item{tidyCovariates}{Add any tidyCovariates mappings here (e.g., if you need to normalize the covariates)}
+
+\item{requireDenseMatrix}{Specify whether the model needs a dense matrix (TRUE or FALSE)}
 }
 \value{
 An object of class plpModel, this is a list that contains:

--- a/tests/testthat/test-existingModel.R
+++ b/tests/testthat/test-existingModel.R
@@ -186,7 +186,34 @@ test_that("Create existing GLM model works", {
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = "linear"))
+  ), mapping = 1))
+  
+  
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', targetId = 'char'))
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', outcomeId = 'char'))
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', populationSettings = 'char'))
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', restrictPlpDataSettings = 'char'))
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', covariateSettings = 'char'))
+  expect_error(createGlmModel(coefficients = data.frame(
+    coefficient = c(1, 2),
+    covariateId = c(1, 2)
+  ), mapping = 'logistic', requireDenseMatrix = 4))
+  
   model <- createGlmModel(
     coefficients = data.frame(
       coefficient = c(1, 2),
@@ -195,8 +222,58 @@ test_that("Create existing GLM model works", {
     intercept = 2,
     mapping = "logistic"
   )
+  expect_equal(model$model$intercept, 2)
+  expect_equal(model$model$mapping, "logistic")
   expect_equal(attr(model, "modelType"), "binary")
-  expect_equal(attr(model, "saveType"), "RToJson")
+  expect_equal(attr(model, "saveType"), "RtoJson")
+  expect_equal(attr(model, "predictionFunction"), "PatientLevelPrediction::predictGlm")
+  
+  model <- createGlmModel(
+    coefficients = data.frame(
+      coefficient = c(1, 2),
+      covariateId = c(1, 2)
+    ),
+    intercept = 2,
+    mapping = "logistic", 
+    targetId = 33, 
+    outcomeId = 1, 
+    covariateSettings = FeatureExtraction::createCovariateSettings(useDemographicsAge = T), 
+    populationSettings = createStudyPopulationSettings(), 
+    restrictPlpDataSettings = createRestrictPlpDataSettings(),
+    requireDenseMatrix = TRUE
+  )
+  expect_equal(model$modelDesign$targetId, 33)
+  expect_equal(model$modelDesign$outcomeId, 1)
+  expect_equal(model$preprocessing$requireDenseMatrix, TRUE)
+  expect_equal(model$modelDesign$populationSettings, createStudyPopulationSettings())
+  expect_equal(model$modelDesign$restrictPlpDataSettings, createRestrictPlpDataSettings())
+  expect_equal(model$modelDesign$covariateSettings, FeatureExtraction::createCovariateSettings(useDemographicsAge = T))
+  
+  madeupFunc <- function(x){return(x)}
+  model <- createGlmModel(
+    coefficients = data.frame(
+      coefficient = c(1, 2),
+      covariateId = c(1, 2)
+    ),
+    intercept = 2,
+    mapping = "madeupFunc"
+  )
+  expect_equal(model$model$mapping, "madeupFunc")
+  expect_equal(attr(model, "modelType"), "binary")
+  expect_equal(attr(model, "saveType"), "RtoJson")
+  expect_equal(attr(model, "predictionFunction"), "PatientLevelPrediction::predictGlm")
+  
+  model <- createGlmModel(
+    coefficients = data.frame(
+      coefficient = c(1, 2),
+      covariateId = c(1, 2)
+    ),
+    intercept = 2,
+    mapping = madeupFunc
+  )
+  expect_equal(model$model$mapping, madeupFunc)
+  expect_equal(attr(model, "modelType"), "binary")
+  expect_equal(attr(model, "saveType"), "RtoJson")
   expect_equal(attr(model, "predictionFunction"), "PatientLevelPrediction::predictGlm")
 })
 

--- a/tests/testthat/test-existingModel.R
+++ b/tests/testthat/test-existingModel.R
@@ -192,27 +192,27 @@ test_that("Create existing GLM model works", {
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', targetId = 'char'))
+  ), mapping = "logistic", targetId = "char"))
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', outcomeId = 'char'))
+  ), mapping = "logistic", outcomeId = "char"))
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', populationSettings = 'char'))
+  ), mapping = "logistic", populationSettings = "char"))
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', restrictPlpDataSettings = 'char'))
+  ), mapping = "logistic", restrictPlpDataSettings = "char"))
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', covariateSettings = 'char'))
+  ), mapping = "logistic", covariateSettings = "char"))
   expect_error(createGlmModel(coefficients = data.frame(
     coefficient = c(1, 2),
     covariateId = c(1, 2)
-  ), mapping = 'logistic', requireDenseMatrix = 4))
+  ), mapping = "logistic", requireDenseMatrix = 4))
   
   model <- createGlmModel(
     coefficients = data.frame(
@@ -237,7 +237,7 @@ test_that("Create existing GLM model works", {
     mapping = "logistic", 
     targetId = 33, 
     outcomeId = 1, 
-    covariateSettings = FeatureExtraction::createCovariateSettings(useDemographicsAge = T), 
+    covariateSettings = FeatureExtraction::createCovariateSettings(useDemographicsAge = TRUE), 
     populationSettings = createStudyPopulationSettings(), 
     restrictPlpDataSettings = createRestrictPlpDataSettings(),
     requireDenseMatrix = TRUE
@@ -247,7 +247,7 @@ test_that("Create existing GLM model works", {
   expect_equal(model$preprocessing$requireDenseMatrix, TRUE)
   expect_equal(model$modelDesign$populationSettings, createStudyPopulationSettings())
   expect_equal(model$modelDesign$restrictPlpDataSettings, createRestrictPlpDataSettings())
-  expect_equal(model$modelDesign$covariateSettings, FeatureExtraction::createCovariateSettings(useDemographicsAge = T))
+  expect_equal(model$modelDesign$covariateSettings, FeatureExtraction::createCovariateSettings(useDemographicsAge = TRUE))
   
   madeupFunc <- function(x){return(x)}
   model <- createGlmModel(


### PR DESCRIPTION
Fixes issue #549 to enable users to specify default values for targetId, outcomeId, population settings, covariates, and feature mappings that need to be done when manually constructing GLMs.  Also enables more flexible mapping functionality (not just logistic). 