### PR TITLE
adding option to skip diagnostics if needed

### DIFF
--- a/R/RunMultiplePlp.R
+++ b/R/RunMultiplePlp.R
@@ -25,6 +25,7 @@
 #' @param databaseDetails               The database settings created using \code{createDatabaseDetails()}
 #' @param modelDesignList                A list of model designs created using \code{createModelDesign()}
 #' @param onlyFetchData                  Only fetches and saves the data object to the output folder without running the analysis.
+#' @param skipDiagnostics                Skip the diagnostics for speed if you just want the models to be developed and evaluated.
 #' @param cohortDefinitions               A list of cohort definitions for the target and outcome cohorts
 #' @param logSettings                    The setting specifying the logging for the analyses created using \code{createLogSettings()}
 #' @param saveDirectory                   Name of the folder where all the outputs will written to.
@@ -92,6 +93,7 @@ runMultiplePlp <- function(
       createModelDesign(targetId = 1, outcomeId = 3, modelSettings = setLassoLogisticRegression())
     ),
     onlyFetchData = FALSE,
+    skipDiagnostics = FALSE,
     cohortDefinitions = NULL,
     logSettings = createLogSettings(
       verbosity = "DEBUG",
@@ -179,7 +181,7 @@ runMultiplePlp <- function(
   }
 
   # runDiagnosis - NEW
-  if (!onlyFetchData) {
+  if (!onlyFetchData & !skipDiagnostics) {
     for (i in 1:nrow(as.data.frame(settingstable))) {
       modelDesign <- modelDesignList[[i]]
       settings <- settingstable[i, ] # just the data locations?
@@ -275,7 +277,8 @@ runMultiplePlp <- function(
         cdmDatabaseNames = databaseDetails$cdmDatabaseName,
         databaseRefIds = databaseDetails$cdmDatabaseId
       ),
-      sqliteLocation = sqliteLocation
+      sqliteLocation = sqliteLocation, 
+      skipDiagnostics = skipDiagnostics
     )
   }
 

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -103,6 +103,7 @@ insertRunPlpToSqlite <- function(
 #' @param cohortDefinitions            A set of one or more cohorts extracted using ROhdsiWebApi::exportCohortDefinitionSet()
 #' @param databaseList             A list created by \code{createDatabaseList} to specify the databases
 #' @param sqliteLocation               (string) location of directory where the sqlite database will be saved
+#' @param skipDiagnostics             Whether to skip uploading the diagnostics
 #'
 #' @return
 #' Returns the location of the sqlite database file
@@ -131,7 +132,9 @@ insertResultsToSqlite <- function(
     resultLocation,
     cohortDefinitions = NULL,
     databaseList = NULL,
-    sqliteLocation = file.path(resultLocation, "sqlite")) {
+    sqliteLocation = file.path(resultLocation, "sqlite"),
+    skipDiagnostics = FALSE
+    ) {
   if (!dir.exists(sqliteLocation)) {
     dir.create(sqliteLocation, recursive = TRUE)
   }
@@ -162,14 +165,16 @@ insertResultsToSqlite <- function(
     modelSaveLocation = sqliteLocation
   )
 
-  # run insert diagnosis
-  addMultipleDiagnosePlpToDatabase(
-    connectionDetails = connectionDetails,
-    databaseSchemaSettings = createDatabaseSchemaSettings(resultSchema = "main"),
-    cohortDefinitions = cohortDefinitions,
-    databaseList = databaseList,
-    resultLocation = resultLocation
-  )
+  # run insert diagnosis - only if skipDiagnostics is FALSE
+  if(!skipDiagnostics){
+    addMultipleDiagnosePlpToDatabase(
+      connectionDetails = connectionDetails,
+      databaseSchemaSettings = createDatabaseSchemaSettings(resultSchema = "main"),
+      cohortDefinitions = cohortDefinitions,
+      databaseList = databaseList,
+      resultLocation = resultLocation
+    )
+  }
 
   return(file.path(sqliteLocation, "databaseFile.sqlite"))
 }

--- a/man/insertResultsToSqlite.Rd
+++ b/man/insertResultsToSqlite.Rd
@@ -8,7 +8,8 @@ insertResultsToSqlite(
   resultLocation,
   cohortDefinitions = NULL,
   databaseList = NULL,
-  sqliteLocation = file.path(resultLocation, "sqlite")
+  sqliteLocation = file.path(resultLocation, "sqlite"),
+  skipDiagnostics = FALSE
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ insertResultsToSqlite(
 \item{databaseList}{A list created by \code{createDatabaseList} to specify the databases}
 
 \item{sqliteLocation}{(string) location of directory where the sqlite database will be saved}
+
+\item{skipDiagnostics}{Whether to skip uploading the diagnostics}
 }
 \value{
 Returns the location of the sqlite database file

--- a/man/runMultiplePlp.Rd
+++ b/man/runMultiplePlp.Rd
@@ -10,6 +10,7 @@ runMultiplePlp(
     setLassoLogisticRegression()), createModelDesign(targetId = 1, outcomeId = 3,
     modelSettings = setLassoLogisticRegression())),
   onlyFetchData = FALSE,
+  skipDiagnostics = FALSE,
   cohortDefinitions = NULL,
   logSettings = createLogSettings(verbosity = "DEBUG", timeStamp = TRUE, logName =
     "runPlp Log"),
@@ -23,6 +24,8 @@ runMultiplePlp(
 \item{modelDesignList}{A list of model designs created using \code{createModelDesign()}}
 
 \item{onlyFetchData}{Only fetches and saves the data object to the output folder without running the analysis.}
+
+\item{skipDiagnostics}{Skip the diagnostics for speed if you just want the models to be developed and evaluated.}
 
 \item{cohortDefinitions}{A list of cohort definitions for the target and outcome cohorts}
 


### PR DESCRIPTION
adding code to skip diagnostics if model development speed is required (when fitting models with the constrained predictors it takes minutes but the diagnostics can take hours, which makes it a bottleneck for large scale model development).