### PR TITLE
fix(resultsDb): handle missing modelType in model settings upload

### DIFF
--- a/R/uploadToDatabaseModelDesign.R
+++ b/R/uploadToDatabaseModelDesign.R
@@ -608,9 +608,32 @@ addModelSetting <- function(conn, resultSchema, targetDialect,
                             tablePrefix = "",
                             json,
                             tempEmulationSchema = getOption("sqlRenderTempEmulationSchema")) {
-  modelType <- json$settings$modelType %||% 
-    attr(json$param, "settings")$modelType %||%
-    "unknown"
+  modelType <- "NULL"
+  if (is.list(json)) {
+    modelTypeCandidate <- NULL
+
+    if (!is.null(json$settings) && is.list(json$settings)) {
+      modelTypeCandidate <- json$settings$modelType
+    }
+
+    if (is.null(modelTypeCandidate) && !is.null(json$param)) {
+      paramSettings <- attr(json$param, "settings")
+      if (is.list(paramSettings)) {
+        modelTypeCandidate <- paramSettings$modelType
+      }
+    }
+
+    if (!is.null(modelTypeCandidate)) {
+      if (is.list(modelTypeCandidate) || length(modelTypeCandidate) == 0) {
+        modelType <- "NULL"
+      } else {
+        modelType <- as.character(modelTypeCandidate)[1]
+        if (is.na(modelType) || !nzchar(modelType)) {
+          modelType <- "NULL"
+        }
+      }
+    }
+  }
   # process json to make it ordered...
   # make sure the json has been converted
   if (!inherits(x = json, what = "character")) {

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -44,3 +44,73 @@ test_that("addModelSetting handles minimal modelSettings objects", {
   expect_true(any(res$modelType == "NULL"))
 })
 
+test_that("addModelSetting derives modelType from supported paths and sanitizes invalid values", {
+  skip_if_not_installed("RSQLite")
+
+  sqliteFile <- file.path(tempdir(), "plp-model-setting-branches.sqlite")
+  if (file.exists(sqliteFile)) unlink(sqliteFile)
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteFile
+  )
+
+  PatientLevelPrediction::createPlpResultTables(
+    connectionDetails = connectionDetails,
+    targetDialect = "sqlite",
+    resultSchema = "main",
+    deleteTables = TRUE,
+    createTables = TRUE,
+    tablePrefix = "",
+    tempEmulationSchema = NULL
+  )
+
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  settingsModelType <- list(
+    settings = list(modelType = "binary"),
+    model = "from-settings"
+  )
+  fallbackModelType <- list(
+    settings = list(),
+    param = structure(list(alpha = 0.1), settings = list(modelType = "survival")),
+    model = "from-param-settings"
+  )
+  listModelType <- list(settings = list(modelType = list("bad")), model = "list-model-type")
+  emptyModelType <- list(settings = list(modelType = character(0)), model = "empty-model-type")
+  blankModelType <- list(settings = list(modelType = ""), model = "blank-model-type")
+  naModelType <- list(settings = list(modelType = NA_character_), model = "na-model-type")
+  charJson <- '{"settings":{"modelType":"ignored"}}'
+
+  inputs <- list(
+    settingsModelType,
+    fallbackModelType,
+    listModelType,
+    emptyModelType,
+    blankModelType,
+    naModelType,
+    charJson
+  )
+  expectedModelTypes <- c("binary", "survival", "NULL", "NULL", "NULL", "NULL", "NULL")
+
+  for (i in seq_along(inputs)) {
+    modelSettingId <- PatientLevelPrediction:::addModelSetting(
+      conn = conn,
+      resultSchema = "main",
+      targetDialect = "sqlite",
+      tablePrefix = "",
+      json = inputs[[i]],
+      tempEmulationSchema = NULL
+    )
+
+    res <- DatabaseConnector::querySql(
+      conn,
+      paste0(
+        "select model_type as modelType from main.model_settings ",
+        "where model_setting_id = ", modelSettingId, ";"
+      )
+    )
+    expect_equal(res$modelType[1], expectedModelTypes[i])
+  }
+})

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -1,0 +1,46 @@
+test_that("addModelSetting handles minimal modelSettings objects", {
+  skip_if_not_installed("RSQLite")
+
+  sqliteFile <- file.path(tempdir(), "plp-model-setting-minimal.sqlite")
+  if (file.exists(sqliteFile)) unlink(sqliteFile)
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteFile
+  )
+
+  PatientLevelPrediction::createPlpResultTables(
+    connectionDetails = connectionDetails,
+    targetDialect = "sqlite",
+    resultSchema = "main",
+    deleteTables = TRUE,
+    createTables = TRUE,
+    tablePrefix = "",
+    tempEmulationSchema = NULL
+  )
+
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  minimalModelSettings <- structure(list(model = "existingGlm"), class = "modelSettings")
+  modelSettingId <- PatientLevelPrediction:::addModelSetting(
+    conn = conn,
+    resultSchema = "main",
+    targetDialect = "sqlite",
+    tablePrefix = "",
+    json = minimalModelSettings,
+    tempEmulationSchema = NULL
+  )
+
+  expect_true(!is.null(modelSettingId))
+  expect_true(is.numeric(modelSettingId) || is.integer(modelSettingId))
+  expect_true(is.finite(modelSettingId) && modelSettingId > 0)
+
+  res <- DatabaseConnector::querySql(
+    conn,
+    "select model_type as modelType from main.model_settings;"
+  )
+  expect_true("modelType" %in% names(res))
+  expect_true(any(res$modelType == "NULL"))
+})
+


### PR DESCRIPTION
Fixes #574.

- Makes model-settings DB upload robust when `modelSettings` lacks `settings$modelType` (legacy/minimal objects)
- Adds regression test covering minimal `modelSettings` in sqlite upload path

Tests
- `Rscript -e "pkgload::load_all('.', quiet=TRUE); testthat::test_file('tests/testthat/test-UploadToDatabaseModelDesign.R')"`
