### PR TITLE
Fix evaluation when outcomes are single-class (#591)

### DIFF
--- a/R/EvaluationSummary.R
+++ b/R/EvaluationSummary.R
@@ -358,6 +358,15 @@ computeAuc <- function(
     prediction,
     confidenceInterval = FALSE) {
   checkDataframe(prediction, c("value", "outcomeCount"), c("numeric", "numeric"))
+  truth <- ifelse(prediction$outcomeCount > 0, 1, 0)
+  truth <- truth[is.finite(truth)]
+  if (length(unique(truth)) < 2) {
+    ParallelLogger::logWarn("Cannot compute AUC: outcomeCount has only one class")
+    if (confidenceInterval) {
+      return(data.frame(auc = NA_real_, auc_lb95ci = NA_real_, auc_ub95ci = NA_real_))
+    }
+    return(NA_real_)
+  }
   if ("rawValue" %in% colnames(prediction)) {
     checkDataframe(prediction, c("rawValue"), c("numeric"))
     scores <- prediction$rawValue
@@ -366,9 +375,9 @@ computeAuc <- function(
   }
 
   if (confidenceInterval) {
-    return(aucWithCi(prediction = scores, truth = prediction$outcomeCount))
+    return(aucWithCi(prediction = scores, truth = ifelse(prediction$outcomeCount > 0, 1, 0)))
   } else {
-    return(aucWithoutCi(prediction = scores, truth = prediction$outcomeCount))
+    return(aucWithoutCi(prediction = scores, truth = ifelse(prediction$outcomeCount > 0, 1, 0)))
   }
 }
 
@@ -397,8 +406,13 @@ computeAuprc <- function(prediction) {
     prediction$value
   }
 
-  positives <- scores[prediction$outcomeCount == 1]
-  negatives <- scores[prediction$outcomeCount == 0]
+  truth <- ifelse(prediction$outcomeCount > 0, 1, 0)
+  positives <- scores[truth == 1]
+  negatives <- scores[truth == 0]
+  if (length(positives) == 0 || length(negatives) == 0) {
+    ParallelLogger::logWarn("Cannot compute AUPRC: outcomeCount has only one class")
+    return(NA_real_)
+  }
   pr <- PRROC::pr.curve(scores.class0 = positives, scores.class1 = negatives)
   return(as.double(pr$auc.integral))
 }
@@ -433,7 +447,7 @@ aucWithoutCi <- function(prediction, truth) {
 brierScore <- function(prediction) {
   brier <- sum((prediction$outcomeCount - prediction$value)^2) / nrow(prediction)
   brierMax <- mean(prediction$value) * (1 - mean(prediction$value))
-  brierScaled <- 1 - brier / brierMax
+  brierScaled <- ifelse(is.finite(brierMax) && brierMax > 0, 1 - brier / brierMax, NA_real_)
   return(list(brier = brier, brierScaled = brierScaled))
 }
 
@@ -527,6 +541,10 @@ averagePrecision <- function(prediction) {
   lab.order <- prediction$outcomeCount[order(-prediction$value)]
   n <- nrow(prediction)
   P <- sum(prediction$outcomeCount > 0)
+  if (P == 0) {
+    ParallelLogger::logWarn("Cannot compute Average Precision: outcomeCount has no positive class")
+    return(NA_real_)
+  }
   val <- rep(0, n)
   val[lab.order > 0] <- 1:P
   return(sum(val / (1:n)) / P)

--- a/R/ThresholdSummary.R
+++ b/R/ThresholdSummary.R
@@ -76,7 +76,7 @@ getThresholdSummary_binary <- function(prediction, evalColumn, ...) {
 
     # do input checks
     if (nrow(predictionOfInterest) < 1) {
-      warning("sparse threshold summary not calculated due to empty dataset")
+      ParallelLogger::logWarn("Sparse threshold summary not calculated due to empty dataset")
       return(NULL)
     }
 
@@ -85,11 +85,11 @@ getThresholdSummary_binary <- function(prediction, evalColumn, ...) {
     N <- n - P
 
     if (N == 0) {
-      warning("Number of negatives is zero")
+      ParallelLogger::logWarn("Number of negatives is zero")
       return(NULL)
     }
     if (P == 0) {
-      warning("Number of positives is zero")
+      ParallelLogger::logWarn("Number of positives is zero")
       return(NULL)
     }
 

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -331,6 +331,59 @@ test_that("temporary sqlite with results works", {
   DatabaseConnector::disconnect(conn)
 })
 
+test_that("external validation with no outcomes uploads to sqlite", {
+  skip_if_not_installed(c("ResultModelManager", "Eunomia"))
+  skip_if_offline()
+
+  validationPopulation <- population
+  validationPopulation$outcomeCount <- 0
+
+  externalVal <- externalValidatePlp(
+    plpModel = plpResult$model,
+    plpData = plpData,
+    population = validationPopulation,
+    settings = createValidationSettings(
+      recalibrate = NULL,
+      runCovariateSummary = FALSE
+    )
+  )
+
+  sqliteLocation <- insertRunPlpToSqlite(
+    runPlp = plpResult,
+    externalValidatePlp = list(externalVal),
+    diagnosePlp = NULL
+  )
+
+  expect_true(file.exists(sqliteLocation))
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteLocation
+  )
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  res <- DatabaseConnector::querySql(conn, "select count(*) as N from main.performances;")
+  expect_gte(res$N[1], 2)
+
+  expect_true(DatabaseConnector::existsTable(
+    connection = conn,
+    databaseSchema = "main",
+    tableName = "evaluation_statistics"
+  ))
+
+  perf <- DatabaseConnector::querySql(conn, "select max(performance_id) as performanceId from main.performances;")
+  evalRows <- DatabaseConnector::querySql(
+    conn,
+    paste0(
+      "select count(*) as N from main.evaluation_statistics where performance_id = ",
+      perf$performanceId[1],
+      ";"
+    )
+  )
+  expect_gt(evalRows$N[1], 0)
+})
+
 # importFromCsv test here as can use previous csv saving
 test_that("import from csv", {
   # TODO remove dependancy on previous test

--- a/tests/testthat/test-evaluation.R
+++ b/tests/testthat/test-evaluation.R
@@ -112,6 +112,31 @@ test_that("Average precision", {
   expect_equal(as.double(avePMetrics), avePPlp)
 })
 
+test_that("Evaluation metrics handle no outcome patients", {
+  ePrediction <- data.frame(
+    rowId = 1:100,
+    ageYear = sample(18:90, 100, replace = TRUE),
+    gender = sample(c(8507, 8532), 100, replace = TRUE),
+    outcomeCount = rep(0, 100),
+    value = runif(100, min = 0.0001, max = 0.9999),
+    evaluationType = rep("Validation", 100)
+  )
+  attr(ePrediction, "metaData") <- list(modelType = "binary")
+
+  expect_true(is.na(computeAuc(ePrediction, confidenceInterval = FALSE)))
+  aucCi <- computeAuc(ePrediction, confidenceInterval = TRUE)
+  expect_true(is.data.frame(aucCi))
+  expect_true(all(is.na(aucCi)))
+  expect_true(is.na(computeAuprc(ePrediction)))
+  expect_true(is.na(averagePrecision(ePrediction)))
+
+  eval <- evaluatePlp(ePrediction, typeColumn = "evaluationType")
+  expect_equal(class(eval), "plpEvaluation")
+  aurocRow <- eval$evaluationStatistics[eval$evaluationStatistics$metric == "AUROC", , drop = FALSE]
+  expect_true(nrow(aurocRow) == 1)
+  expect_true(is.na(as.numeric(aurocRow$value[1])))
+})
+
 
 test_that("Calibration metrics", {
   skip_if_not_installed("ResourceSelection")


### PR DESCRIPTION
Fixes evaluation edge cases where a prediction subset has only one class (e.g. no outcome patients in an external validation stratum).

Changes:
- Return `NA` for AUROC/AUPRC/Average Precision (and related CIs) when metrics are undefined due to single-class outcomes.
- Avoid emitting base `warning()` from threshold summary for this expected condition (log via `ParallelLogger::logWarn()` instead).
- Add regression test covering the no-positives path.

Notes:
- Behavior is backwards compatible in the sense that evaluation no longer errors; metrics become `NA` when they cannot be computed.
