### PR TITLE
fix(lightgbm): save model as json with txt fallback

### DIFF
--- a/R/LightGBM.R
+++ b/R/LightGBM.R
@@ -235,11 +235,7 @@ saveLoadLightGBM <- function() {
   rlang::check_installed("lightgbm")
   list(
     save = function(model, file) {
-      tmpFile <- tempfile("lgbm_model_", fileext = ".txt")
-      on.exit(unlink(tmpFile), add = TRUE)
-      lightgbm::lgb.save(model, tmpFile)
-
-      modelTxt <- paste(readLines(tmpFile, warn = FALSE), collapse = "\n")
+      modelTxt <- model$save_model_to_string(NULL)
 
       ParallelLogger::saveSettingsToJson(
         object = list(

--- a/R/LightGBM.R
+++ b/R/LightGBM.R
@@ -235,10 +235,43 @@ saveLoadLightGBM <- function() {
   rlang::check_installed("lightgbm")
   list(
     save = function(model, file) {
-      lightgbm::lgb.save(model, file)
+      tmpFile <- tempfile("lgbm_model_", fileext = ".txt")
+      on.exit(unlink(tmpFile), add = TRUE)
+      lightgbm::lgb.save(model, tmpFile)
+
+      modelTxt <- paste(readLines(tmpFile, warn = FALSE), collapse = "\n")
+
+      ParallelLogger::saveSettingsToJson(
+        object = list(
+          modelType = "lightGBM",
+          modelFormat = "lightgbm_txt",
+          model = modelTxt
+        ),
+        fileName = file
+      )
     },
     load = function(file) {
-      lightgbm::lgb.load(file)
+      firstLine <- tryCatch(readLines(file, n = 1, warn = FALSE), error = function(e) "")
+      firstLine <- trimws(firstLine)
+
+      wrapper <- NULL
+      if (nzchar(firstLine) && startsWith(firstLine, "{")) {
+        wrapper <- tryCatch(
+          ParallelLogger::loadSettingsFromJson(fileName = file),
+          error = function(e) NULL
+        )
+      }
+
+      if (!is.null(wrapper) &&
+        is.list(wrapper) &&
+        identical(wrapper$modelType, "lightGBM") &&
+        identical(wrapper$modelFormat, "lightgbm_txt") &&
+        is.character(wrapper$model) &&
+        length(wrapper$model) == 1) {
+        return(lightgbm::lgb.load(model_str = wrapper$model))
+      }
+
+      lightgbm::lgb.load(filename = file)
     }
   )
 }

--- a/tests/testthat/test-LightGBM.R
+++ b/tests/testthat/test-LightGBM.R
@@ -116,6 +116,11 @@ test_that("LightGBM working checks", {
   savePath <- tempfile("lgbmTest_")
   unlink(savePath, recursive = TRUE)
   savePlpModel(fitModel, savePath)
+
+  # current format should be JSON:
+  expect_true(file.exists(file.path(savePath, "model.json")))
+  expect_silent(ParallelLogger::loadSettingsFromJson(file.path(savePath, "model.json")))
+
   loadModel <- loadPlpModel(savePath)
 
   expect_s3_class(loadModel, "plpModel")
@@ -135,4 +140,11 @@ test_that("LightGBM working checks", {
   expect_equal(predLoad$value, predFit$value, tolerance = 0e-10)
   expect_true(all(predLoad$value >= 0))
   expect_true(all(predLoad$value <= 1))
+
+  # backwards compatibility: old LightGBM serialization (raw text in model.json)
+  lightgbm::lgb.save(fitModel$model, file.path(savePath, "model.json"))
+  expect_error(ParallelLogger::loadSettingsFromJson(file.path(savePath, "model.json")))
+  loadModelOld <- loadPlpModel(savePath)
+  expect_s3_class(loadModelOld, "plpModel")
+  expect_equal(class(loadModelOld$model), c("lgb.Booster", "R6"))
 })

--- a/tests/testthat/test-LightGBM.R
+++ b/tests/testthat/test-LightGBM.R
@@ -119,7 +119,18 @@ test_that("LightGBM working checks", {
 
   # current format should be JSON:
   expect_true(file.exists(file.path(savePath, "model.json")))
-  expect_silent(ParallelLogger::loadSettingsFromJson(file.path(savePath, "model.json")))
+  serialized <- ParallelLogger::loadSettingsFromJson(file.path(savePath, "model.json"))
+  expect_equal(serialized$modelType, "lightGBM")
+  expect_equal(serialized$modelFormat, "lightgbm_txt")
+  expect_true(is.character(serialized$model))
+  expect_length(serialized$model, 1)
+  expect_match(serialized$model, "^tree")
+  expect_match(serialized$model, "version=")
+  expect_equal(serialized$model, fitModel$model$save_model_to_string(NULL))
+
+  loadedBooster <- lightgbm::lgb.load(model_str = serialized$model)
+  expect_equal(class(loadedBooster), c("lgb.Booster", "R6"))
+  expect_equal(loadedBooster$num_trees(), fitModel$model$num_trees())
 
   loadModel <- loadPlpModel(savePath)
 


### PR DESCRIPTION
Fixes #619.

- LightGBM models are now saved as valid JSON (wrapper containing the LightGBM text model).
- Loading remains backwards compatible with existing saved models where the file model.json contained the raw LightGBM text format.
- Adds a regression test covering both formats.