### PR TITLE
fix(sklearn): avoid deprecated AdaBoost algorithm param

### DIFF
--- a/R/SklearnToJson.R
+++ b/R/SklearnToJson.R
@@ -292,9 +292,10 @@ serializeAdaboost <- function(model) {
 deSerializeAdaboost <- function(model_dict) {
   np <- reticulate::import("numpy", convert = FALSE)
   sklearn <- reticulate::import("sklearn", convert = FALSE)
+  params <- sanitizeSklearnAdaBoostParams(reticulate::py_to_r(model_dict["params"]))
   model <- do.call(
     sklearn$ensemble$AdaBoostClassifier,
-    reticulate::py_to_r(model_dict["params"])
+    params
   )
   estimators <- list()
   for (i in 1:length(model_dict$estimators_)) {
@@ -308,6 +309,23 @@ deSerializeAdaboost <- function(model_dict) {
   model$estimator_weights_ <- np$array(model_dict["estimator_weights_"])
 
   return(model)
+}
+
+sanitizeSklearnAdaBoostParams <- function(params) {
+  if (!is.list(params)) {
+    return(params)
+  }
+
+  # scikit-learn 1.8 deprecates `algorithm` for AdaBoostClassifier.
+  params$algorithm <- NULL
+
+  # scikit-learn renamed `base_estimator` -> `estimator` (keep backwards compatibility).
+  if (!is.null(params$base_estimator) && is.null(params$estimator)) {
+    params$estimator <- params$base_estimator
+  }
+  params$base_estimator <- NULL
+
+  return(params)
 }
 
 serializeNaiveBayes <- function(model) {

--- a/tests/testthat/test-sklearnAdaboostParams.R
+++ b/tests/testthat/test-sklearnAdaboostParams.R
@@ -1,0 +1,40 @@
+# Copyright 2026 Observational Health Data Sciences and Informatics
+#
+# This file is part of PatientLevelPrediction
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test_that("sanitizeSklearnAdaBoostParams drops deprecated keys", {
+  params <- list(
+    algorithm = "SAMME.R",
+    n_estimators = 10L
+  )
+
+  sanitized <- PatientLevelPrediction:::sanitizeSklearnAdaBoostParams(params)
+
+  expect_null(sanitized$algorithm)
+  expect_equal(sanitized$n_estimators, 10L)
+})
+
+test_that("sanitizeSklearnAdaBoostParams maps base_estimator to estimator", {
+  params <- list(
+    base_estimator = "tree",
+    n_estimators = 10L
+  )
+
+  sanitized <- PatientLevelPrediction:::sanitizeSklearnAdaBoostParams(params)
+
+  expect_null(sanitized$base_estimator)
+  expect_equal(sanitized$estimator, "tree")
+})
+


### PR DESCRIPTION
Fixes #602.

- Drops the deprecated algorithm constructor param when recreating AdaBoostClassifier from our sklearn JSON.
- Keeps backwards compatibility by mapping base_estimator -> estimator when present.
- Adds a small unit test for the param sanitization logic (does not require a working sklearn install).