### PR TITLE
fix(upload): normalize hyperparameter metadata for DB viewer

### DIFF
--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -185,14 +185,19 @@ fitCyclopsModel <- function(
       x$out_sample_auc
     }))
     if (length(cvPerFold) > 0) {
+      cvMean <- mean(cvPerFold, na.rm = TRUE)
+      if (!is.finite(cvMean)) {
+        cvMean <- NA_real_
+      }
       cvPerFold <- data.frame(
         metric = "AUC",
-        fold = 1:length(cvPerFold),
-        value = cvPerFold,
+        fold = c("CV", paste0("Fold", seq_along(cvPerFold))),
+        value = c(cvMean, cvPerFold),
         startingVariance = ifelse(is.null(param$priorParams$variance), "NULL", param$priorParams$variance),
         lowerLimit = ifelse(is.null(param$lowerLimit), "NULL", param$lowerLimit),
         upperLimit = ifelse(is.null(param$upperLimit), "NULL", param$upperLimit),
-        tolerance = ifelse(is.null(settings$tolerance), "NULL", settings$tolerance)
+        tolerance = ifelse(is.null(settings$tolerance), "NULL", settings$tolerance),
+        stringsAsFactors = FALSE
       )
     } else {
       cvPerFold <- data.frame()

--- a/R/RunMultiplePlp.R
+++ b/R/RunMultiplePlp.R
@@ -394,6 +394,7 @@ createModelDesign <- function(
     preprocessSettings = preprocessSettings,
     modelSettings = modelSettings,
     splitSettings = splitSettings,
+    hyperparameterSettings = hyperparameterSettings,
     executeSettings = createExecuteSettings(
       runSplitData = TRUE,
       runSampleData = useSample,

--- a/R/SklearnToJson.R
+++ b/R/SklearnToJson.R
@@ -154,6 +154,12 @@ deSerializeTree <- function(tree_dict, nFeatures, nClasses, nOutputs) {
 }
 
 serializeDecisionTree <- function(model) {
+  nFeaturesIn <- if (reticulate::py_has_attr(model, "n_features_in_")) {
+    model$n_features_in_
+  } else {
+    model$tree_$n_features
+  }
+
   tree <- serializeTree(model$tree_)
   dtypes <- tree[[2]]
   tree <- tree[[1]]
@@ -163,7 +169,7 @@ serializeDecisionTree <- function(model) {
     "feature_importances_" = model$feature_importances_$tolist(),
     "max_features_" = model$max_features_,
     "n_classes_" = py$int(model$n_classes_),
-    "n_features_in_" = model$n_features_in_,
+    "n_features_in_" = nFeaturesIn,
     "n_outputs_" = model$n_outputs_,
     "tree_" = tree,
     "classes_" = model$classes_$tolist(),
@@ -190,7 +196,7 @@ deSerializeDecisionTree <- function(model_dict) {
   deserialized_model$classes_ <- np$array(model_dict["classes_"])
   deserialized_model$max_features_ <- model_dict["max_features_"]
   deserialized_model$n_classes_ <- model_dict["n_classes_"]
-  deserialized_model$n_features_in <- model_dict["n_features_in_"]
+  deserialized_model$n_features_in_ <- model_dict["n_features_in_"]
   deserialized_model$n_outputs_ <- model_dict["n_outputs_"]
 
   tree <- deSerializeTree(

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -733,7 +733,14 @@ insertModelInDatabase <- function(
 
   # need hyperParamSearch for shiny app but the other parts
   # are too large to store into the database
-  trainDetails <- list(hyperParamSearch = model$trainDetails$hyperParamSearch)
+  hyperparameterSettings <- NULL
+  if (!is.null(model$modelDesign) && is.list(model$modelDesign)) {
+    hyperparameterSettings <- model$modelDesign$hyperparameterSettings
+  }
+  trainDetails <- list(
+    hyperParamSearch = model$trainDetails$hyperParamSearch,
+    hyperparameterSettings = hyperparameterSettings
+  )
 
   # create this function
   modelId <- addModel(

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -733,12 +733,15 @@ insertModelInDatabase <- function(
 
   # need hyperParamSearch for shiny app but the other parts
   # are too large to store into the database
+  hyperParamSearch <- normalizeHyperParamSearchForDatabase(
+    model$trainDetails$hyperParamSearch
+  )
   hyperparameterSettings <- NULL
   if (!is.null(model$modelDesign) && is.list(model$modelDesign)) {
     hyperparameterSettings <- model$modelDesign$hyperparameterSettings
   }
   trainDetails <- list(
-    hyperParamSearch = model$trainDetails$hyperParamSearch,
+    hyperParamSearch = hyperParamSearch,
     hyperparameterSettings = hyperparameterSettings
   )
 
@@ -775,6 +778,39 @@ insertModelInDatabase <- function(
   )
 
   return(invisible(modelId))
+}
+
+normalizeHyperParamSearchForDatabase <- function(hyperParamSearch) {
+  if (is.null(hyperParamSearch)) {
+    return(data.frame())
+  }
+
+  if (is.data.frame(hyperParamSearch)) {
+    return(hyperParamSearch)
+  }
+
+  if (is.list(hyperParamSearch)) {
+    fromSummary <- lapply(hyperParamSearch, function(entry) {
+      if (is.list(entry) && is.data.frame(entry$hyperSummary)) {
+        return(entry$hyperSummary)
+      }
+      NULL
+    })
+    fromSummary <- Filter(Negate(is.null), fromSummary)
+    if (length(fromSummary) > 0) {
+      return(dplyr::bind_rows(fromSummary))
+    }
+
+    directDataFrames <- Filter(is.data.frame, hyperParamSearch)
+    if (length(directDataFrames) > 0) {
+      return(dplyr::bind_rows(directDataFrames))
+    }
+  }
+
+  ParallelLogger::logWarn(
+    "Unable to coerce hyperParamSearch to data.frame; storing empty table for compatibility."
+  )
+  data.frame()
 }
 
 addModel <- function(

--- a/R/uploadToDatabaseModelDesign.R
+++ b/R/uploadToDatabaseModelDesign.R
@@ -41,6 +41,10 @@ insertModelDesignInDatabase <- function(
     cohortDefinitions) {
   # REMOVE THIS
   if (inherits(object, "externalValidatePlp") || inherits(object, "runPlp")) {
+    hyperparameterSettings <- object$model$modelDesign$hyperparameterSettings
+    if (is.null(hyperparameterSettings)) {
+      hyperparameterSettings <- createHyperparameterSettings()
+    }
     object <- PatientLevelPrediction::createModelDesign(
       targetId = object$model$modelDesign$targetId,
       outcomeId = object$model$modelDesign$outcomeId,
@@ -51,6 +55,7 @@ insertModelDesignInDatabase <- function(
       sampleSettings = object$model$modelDesign$sampleSettings,
       preprocessSettings = object$model$modelDesign$preprocessSettings,
       modelSettings = object$model$modelDesign$modelSettings,
+      hyperparameterSettings = hyperparameterSettings,
       runCovariateSummary = TRUE
     )
   }

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -258,6 +258,11 @@ test_that("temporary sqlite with results works", {
   expect_true(length(list.files(res$plpModelFile[1], all.files = TRUE, recursive = TRUE)) > 0)
   expect_true(nzchar(res$modelType[1]))
   expect_true(nzchar(res$trainDetails[1]))
+  trainDetails <- ParallelLogger::convertJsonToSettings(res$trainDetails[1])
+  expect_true("hyperParamSearch" %in% names(trainDetails))
+  expect_true("hyperparameterSettings" %in% names(trainDetails))
+  expect_equal(trainDetails$hyperparameterSettings$search, "grid")
+  expect_equal(trainDetails$hyperparameterSettings$tuningMetric$name, "AUC")
 
   expectedIntercept <- PatientLevelPrediction:::getModelIntercept(plpResult$model)
   expect_equal(res$intercept[1], expectedIntercept, tolerance = 1e-4)

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -271,6 +271,65 @@ test_that("temporary sqlite with results works", {
   DatabaseConnector::disconnect(conn)
 })
 
+test_that("list hyperParamSearch is flattened for sqlite uploads", {
+  skip_if_not_installed(c("ResultModelManager", "Eunomia"))
+  skip_if_offline()
+
+  runPlpListHyper <- plpResult
+  runPlpListHyper$model$trainDetails$hyperParamSearch <- list(
+    list(
+      metric = "AUC",
+      param = list(numIterations = 30, learningRate = 0.1),
+      cvPerformance = 0.60,
+      cvPerformancePerFold = c(0.59, 0.61),
+      hyperSummary = data.frame(
+        metric = "AUC",
+        fold = c("CV", "Fold1", "Fold2"),
+        value = c(0.60, 0.59, 0.61),
+        numIterations = c(30, 30, 30),
+        learningRate = c(0.1, 0.1, 0.1),
+        stringsAsFactors = FALSE
+      )
+    ),
+    list(
+      metric = "AUC",
+      param = list(numIterations = 50, learningRate = 0.05),
+      cvPerformance = 0.58,
+      cvPerformancePerFold = c(0.57, 0.59),
+      hyperSummary = data.frame(
+        metric = "AUC",
+        fold = c("CV", "Fold1", "Fold2"),
+        value = c(0.58, 0.57, 0.59),
+        numIterations = c(50, 50, 50),
+        learningRate = c(0.05, 0.05, 0.05),
+        stringsAsFactors = FALSE
+      )
+    )
+  )
+
+  sqliteLocation <- insertRunPlpToSqlite(
+    runPlp = runPlpListHyper,
+    externalValidatePlp = NULL
+  )
+  expect_true(file.exists(sqliteLocation))
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteLocation
+  )
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  res <- DatabaseConnector::querySql(conn, "select train_details as trainDetails from main.models;")
+  expect_true(nrow(res) > 0)
+  trainDetails <- ParallelLogger::convertJsonToSettings(res$trainDetails[1])
+
+  expect_true("hyperParamSearch" %in% names(trainDetails))
+  expect_true(is.data.frame(trainDetails$hyperParamSearch))
+  expect_true(nrow(trainDetails$hyperParamSearch) >= 6)
+  expect_true(all(c("metric", "fold", "value") %in% colnames(trainDetails$hyperParamSearch)))
+})
+
 # SQL lite test
 test_that("temporary sqlite with results works", {
   skip_if_not_installed(c("ResultModelManager", "Eunomia"))

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -330,6 +330,94 @@ test_that("list hyperParamSearch is flattened for sqlite uploads", {
   expect_true(all(c("metric", "fold", "value") %in% colnames(trainDetails$hyperParamSearch)))
 })
 
+test_that("normalizeHyperParamSearchForDatabase handles all supported shapes", {
+  baseDf <- data.frame(
+    metric = "AUC",
+    fold = "CV",
+    value = 0.7,
+    stringsAsFactors = FALSE
+  )
+
+  normalizedNull <- PatientLevelPrediction:::normalizeHyperParamSearchForDatabase(NULL)
+  expect_true(is.data.frame(normalizedNull))
+  expect_equal(nrow(normalizedNull), 0)
+
+  normalizedDf <- PatientLevelPrediction:::normalizeHyperParamSearchForDatabase(baseDf)
+  expect_equal(normalizedDf, baseDf)
+
+  normalizedFromSummary <- PatientLevelPrediction:::normalizeHyperParamSearchForDatabase(
+    list(
+      list(hyperSummary = baseDf),
+      list(hyperSummary = transform(baseDf, fold = "Fold1", value = 0.69))
+    )
+  )
+  expect_true(is.data.frame(normalizedFromSummary))
+  expect_equal(nrow(normalizedFromSummary), 2)
+  expect_true(all(c("metric", "fold", "value") %in% colnames(normalizedFromSummary)))
+
+  normalizedFromDirect <- PatientLevelPrediction:::normalizeHyperParamSearchForDatabase(
+    list(
+      baseDf,
+      transform(baseDf, fold = "Fold2", value = 0.68)
+    )
+  )
+  expect_true(is.data.frame(normalizedFromDirect))
+  expect_equal(nrow(normalizedFromDirect), 2)
+  expect_true(all(c("CV", "Fold2") %in% normalizedFromDirect$fold))
+
+  normalizedUnknown <- PatientLevelPrediction:::normalizeHyperParamSearchForDatabase(
+    list(list(metric = "AUC", value = 0.7))
+  )
+  expect_true(is.data.frame(normalizedUnknown))
+  expect_equal(nrow(normalizedUnknown), 0)
+})
+
+test_that("insertModelDesignInDatabase handles missing hyperparameterSettings in runPlp model", {
+  skip_if_not_installed(c("ResultModelManager", "Eunomia"))
+  skip_if_offline()
+
+  sqliteLocation <- file.path(tempdir(), "issue620-modeldesign-fallback.sqlite")
+  if (file.exists(sqliteLocation)) {
+    file.remove(sqliteLocation)
+  }
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteLocation
+  )
+
+  createPlpResultTables(
+    connectionDetails = connectionDetails,
+    targetDialect = "sqlite",
+    resultSchema = "main",
+    deleteTables = TRUE,
+    createTables = TRUE,
+    tablePrefix = ""
+  )
+
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  runPlpNoHyper <- plpResult
+  runPlpNoHyper$model$modelDesign$hyperparameterSettings <- NULL
+
+  modelDesignId <- insertModelDesignInDatabase(
+    object = runPlpNoHyper,
+    conn = conn,
+    databaseSchemaSettings = createDatabaseSchemaSettings(resultSchema = "main"),
+    cohortDefinitions = data.frame(
+      cohortName = c("blank1", "blank2", "blank3"),
+      cohortId = c(1, 2, 3),
+      json = rep("bla", 3)
+    )
+  )
+
+  expect_false(is.null(modelDesignId))
+  expect_true(is.numeric(modelDesignId) || is.integer(modelDesignId))
+
+  countRes <- DatabaseConnector::querySql(conn, "select count(*) as n from main.model_designs;")
+  expect_true(countRes$n[1] > 0)
+})
+
 # SQL lite test
 test_that("temporary sqlite with results works", {
   skip_if_not_installed(c("ResultModelManager", "Eunomia"))

--- a/tests/testthat/test-cyclopsModels.R
+++ b/tests/testthat/test-cyclopsModels.R
@@ -328,6 +328,10 @@ test_that("test logistic regression runs", {
   )
 
   expect_true("covariateValue" %in% colnames(fitModel$covariateImportance))
+  expect_true(is.data.frame(fitModel$trainDetails$hyperParamSearch))
+  if (nrow(fitModel$trainDetails$hyperParamSearch) > 0) {
+    expect_true("CV" %in% fitModel$trainDetails$hyperParamSearch$fold)
+  }
 
   expect_equal(fitModel$modelDesign$outcomeId, attr(trainData, "metaData")$outcomeId)
   expect_equal(fitModel$modelDesign$targetId, attr(trainData, "metaData")$targetId)

--- a/tests/testthat/test-multiplePlp.R
+++ b/tests/testthat/test-multiplePlp.R
@@ -37,6 +37,8 @@ test_that("createModelDesign - test working", {
   expect_equal(analysis1$sampleSettings, list(createSampleSettings(type = "none")))
   expect_equal(analysis1$preprocessSettings, createPreprocessSettings())
   expect_equal(analysis1$splitSettings, createDefaultSplitSetting(splitSeed = 1))
+  expect_equal(analysis1$hyperparameterSettings$search, "grid")
+  expect_equal(analysis1$hyperparameterSettings$tuningMetric$name, "AUC")
   expect_equal(analysis1$modelSettings, setLassoLogisticRegression(seed = 12))
   expect_equal(
     analysis1$executeSettings,
@@ -74,6 +76,8 @@ test_that("loading analyses settings", {
   expect_equal(analysis1$preprocessSettings, analysisSetting$analyses[[1]]$preprocessSettings)
   expect_equal(analysis1$modelSettings, analysisSetting$analyses[[1]]$modelSettings)
   expect_equal(analysis1$splitSettings, analysisSetting$analyses[[1]]$splitSettings)
+  expect_equal(analysisSetting$analyses[[1]]$hyperparameterSettings$search, "grid")
+  expect_equal(analysisSetting$analyses[[1]]$hyperparameterSettings$tuningMetric$name, "AUC")
   expect_equal(analysis1$executeSettings, analysisSetting$analyses[[1]]$executeSettings)
 })
 

--- a/tests/testthat/test-sklearnJson.R
+++ b/tests/testthat/test-sklearnJson.R
@@ -65,6 +65,9 @@ test_that("Random forest to json is correct", {
 
   loadedModel <- sklearnFromJson(path)
 
+  expect_true(reticulate::py_has_attr(loadedModel$estimators_[0], "n_features_in_"))
+  expect_no_error(sklearnToJson(loadedModel, path))
+
   loadedPredictions <- reticulate::py_to_r(loadedModel$predict_proba(xUnseen))
 
   expect_true(all.equal(predictions, loadedPredictions))
@@ -82,6 +85,9 @@ test_that("Adaboost to json is correct", {
   sklearnToJson(model, path)
 
   loadedModel <- sklearnFromJson(path)
+
+  expect_true(reticulate::py_has_attr(loadedModel$estimators_[0], "n_features_in_"))
+  expect_no_error(sklearnToJson(loadedModel, path))
 
   loadedPredictions <- reticulate::py_to_r(loadedModel$predict_proba(xUnseen))
 


### PR DESCRIPTION
## Summary

This PR completes the Issue 620 upload/viewer hardening for hyperparameter metadata and adds sklearn serialization regression handling.

### What changed

- Persisted `hyperparameterSettings` through `createModelDesign()` in `runMultiplePlp` flows.
- Normalized uploaded `train_details$hyperParamSearch` to a flat `data.frame` for DB viewer compatibility.
- Updated Cyclops CV metadata shape to include a summary `CV` row plus per-fold rows.
- When `insertModelDesignInDatabase()` is called with a `runPlp` or `externalValidatePlp` object, it now carries forward that model’s `hyperparameterSettings`; if they are missing, it explicitly applies default hyperparameter settings (`grid` + `AUC`) instead of leaving this field unset.
- Fixed sklearn tree deserialization to restore fitted feature metadata as `n_features_in_` (scikit-learn fitted-attribute convention).
- Kept sklearn serializer robust for deserialized models and added regression checks for RF/AdaBoost re-serialization.

### Why

- Shiny/DB hyperparameter views expect tabular hyperparameter search content.
- Some models (Cyclops/sklearn-derived paths) produced metadata shapes that were inconsistent for downstream display.
- sklearn upload could fail on re-serialization after JSON load when fitted feature metadata was not restored with trailing underscore.
- Model-design inserts from `runPlp`/`externalValidatePlp` could otherwise lose hyperparameter setting metadata when not explicitly present.

## Validation

- Tested SQLite upload for multi-model runs (Cyclops lasso, xgboost, lightGBM, sklearn random forest) with hyperparameter tuning enabled.
- Verified uploaded `train_details$hyperParamSearch` is tabular and populated for these model types.
- Tested Shiny hyperparameter viewing from uploaded results for:
  - standard AUC tuning runs
  - alternate tuning metric runs (for supported models)
  - mixed multi-model result sets including sklearn random forest
- Confirmed `viewMultiplePlp()` starts successfully and hyperparameter tables are rendered from uploaded DB content.
- Added/updated tests in:
  - `tests/testthat/test-cyclopsModels.R`
  - `tests/testthat/test-multiplePlp.R`
  - `tests/testthat/test-UploadToDatabase.R`
  - `tests/testthat/test-sklearnJson.R`
