### PR TITLE
fix: serialize simpleImputer metadata in savePlpModel

### DIFF
--- a/R/Imputation.R
+++ b/R/Imputation.R
@@ -896,7 +896,7 @@ simpleImpute <- function(trainData, featureEngineeringSettings, done = FALSE) {
     attr(featureEngineeringSettings, "missingInfo") <-
       outputData$covariateData$missingInfo %>%
       dplyr::collect()
-    attr(featureEngineeringSettings, "imputer") <- numericData$imputedValues
+    attr(featureEngineeringSettings, "imputer") <- as.data.frame(numericData$imputedValues)
     done <- TRUE
   } else {
     ParallelLogger::logInfo("Applying imputation to test data with simpleImputer

--- a/tests/testthat/test-imputation.R
+++ b/tests/testthat/test-imputation.R
@@ -546,6 +546,35 @@ test_that("simpleImpute fills missing values across many continuous features", {
   expect_equal(testImputedValues$covariateValue, testImputedValues$expectedValue)
 })
 
+test_that("simpleImpute stores serializable imputer metadata", {
+  trainData <- makeToyImputationData(n = 80, seed = 13)
+  missingData <- createMissingData(trainData, 0.2)
+  imputer <- createSimpleImputer(
+    method = "mean",
+    missingThreshold = 0.3,
+    addMissingIndicator = FALSE
+  )
+
+  imputedData <- simpleImpute(missingData, imputer, done = FALSE)
+  settings <- attr(imputedData$covariateData, "metaData")$featureEngineering$simpleImputer$settings$featureEngineeringSettings
+  imputedValues <- attr(settings, "imputer")
+
+  expect_false(inherits(imputedValues, "tbl_Andromeda"))
+  expect_true(is.data.frame(imputedValues))
+  expect_true(all(c("covariateId", "imputedValues") %in% colnames(imputedValues)))
+
+  serializablePreprocessing <- list(
+    featureEngineering = list(
+      simpleImputer = list(
+        funct = "simpleImpute",
+        settings = list(featureEngineeringSettings = settings, done = TRUE)
+      )
+    )
+  )
+  jsonFile <- tempfile(fileext = ".json")
+  expect_no_error(ParallelLogger::saveSettingsToJson(serializablePreprocessing, jsonFile))
+})
+
 test_that("IterativeImputer works", {
   skip_if_not_installed("glmnet")
   trainData <- makeToyImputationData(n = 80, seed = 7)


### PR DESCRIPTION
## Summary
- store simpleImpute runtime imputer values as a plain data.frame in featureEngineeringSettings
- avoid saving lazy tbl_Andromeda objects in model metadata, which breaks JSON serialization during savePlpModel
- add regression test to ensure imputer metadata is serializable and ParallelLogger::saveSettingsToJson() succeeds

## Root cause
simpleImpute() was assigning attr(featureEngineeringSettings, "imputer") <- numericData$imputedValues where numericData$imputedValues could be a lazy Andromeda/DBI table. During model save, this metadata is serialized to JSON and fails.

## Validation
- reproduced failure from saved model object and isolated to simpleImputer imputer attr
- added regression test in tests/testthat/test-imputation.R
