### PR TITLE
feat(upload): persist hyperparameter settings in model designs

### DIFF
--- a/R/ImportFromCsv.R
+++ b/R/ImportFromCsv.R
@@ -277,6 +277,20 @@ getModelDesignSettingTable <- function(modeldesignsRow) {
       "preprocessSettings"
     )
   )
+
+  if ("hyperparameter_setting_id" %in% colnames(modeldesignsRow) &&
+    !is.na(modeldesignsRow$hyperparameter_setting_id[1])) {
+    hyperparameterRow <- data.frame(
+      tableName = "hyperparameter_settings",
+      idColumn = "hyperparameter_setting_id",
+      jsonColumn = "hyperparameter_settings_json",
+      convertJson = TRUE,
+      value = modeldesignsRow$hyperparameter_setting_id[1],
+      modelDesignInput = "hyperparameterSettings"
+    )
+    result <- rbind(result, hyperparameterRow)
+  }
+
   return(result)
 }
 
@@ -392,7 +406,7 @@ extractObjectFromCsv <- function(
 
   modelDesignId <- poi$model_design_id
   modeldesigns <- readr::read_csv(file.path(csvFolder, csvFileNames[grep("model_designs", csvFileNames)]))
-  # model_design_id	target_id	outcome_id	tar_id	plp_data_setting_id	population_setting_id	model_setting_id	covariate_setting_id	sample_setting_id	split_setting_id	feature_engineering_setting_id	tidy_covariates_setting_id
+  # model_design_id	target_id	outcome_id	tar_id	plp_data_setting_id	population_setting_id	model_setting_id	covariate_setting_id	sample_setting_id	split_setting_id	feature_engineering_setting_id	tidy_covariates_setting_id	hyperparameter_setting_id
   modeldesigns <- modeldesigns[modeldesigns$model_design_id == modelDesignId, , ]
 
   modelDesignSettingTable <- getModelDesignSettingTable(
@@ -558,7 +572,7 @@ extractDiagnosticFromCsv <- function(
 
   modelDesignId <- doi$model_design_id
   modeldesigns <- readr::read_csv(file.path(csvFolder, csvFileNames[grep("model_designs", csvFileNames)]))
-  # model_design_id	target_id	outcome_id	tar_id	plp_data_setting_id	population_setting_id	model_setting_id	covariate_setting_id	sample_setting_id	split_setting_id	feature_engineering_setting_id	tidy_covariates_setting_id
+  # model_design_id	target_id	outcome_id	tar_id	plp_data_setting_id	population_setting_id	model_setting_id	covariate_setting_id	sample_setting_id	split_setting_id	feature_engineering_setting_id	tidy_covariates_setting_id	hyperparameter_setting_id
   modeldesigns <- modeldesigns[modeldesigns$model_design_id == modelDesignId, , ]
 
   modelDesignSettingTable <- getModelDesignSettingTable(

--- a/R/uploadToDatabase.R
+++ b/R/uploadToDatabase.R
@@ -968,6 +968,7 @@ getPlpResultTables <- function() {
       "MODELS",
       "MODEL_DESIGNS",
       "MODEL_SETTINGS",
+      "HYPERPARAMETER_SETTINGS",
       "COVARIATE_SETTINGS",
       "POPULATION_SETTINGS",
       "FEATURE_ENGINEERING_SETTINGS",

--- a/R/uploadToDatabaseModelDesign.R
+++ b/R/uploadToDatabaseModelDesign.R
@@ -208,6 +208,20 @@ insertModelDesignSettings <- function(
   )
   ParallelLogger::logInfo(paste0("splitId: ", splitId))
 
+  hyperparameterSettings <- object$hyperparameterSettings
+  if (is.null(hyperparameterSettings)) {
+    hyperparameterSettings <- createHyperparameterSettings()
+  }
+  hyperparameterSetId <- addHyperparameterSetting(
+    conn = conn,
+    resultSchema = databaseSchemaSettings$resultSchema,
+    targetDialect = databaseSchemaSettings$targetDialect,
+    json = hyperparameterSettings,
+    tablePrefix = databaseSchemaSettings$tablePrefix,
+    tempEmulationSchema = databaseSchemaSettings$tempEmulationSchema
+  )
+  ParallelLogger::logInfo(paste0("hyperparameterSetId: ", hyperparameterSetId))
+
   # create this function
   modelDesignId <- addModelDesign( # need to create
     conn = conn,
@@ -224,6 +238,7 @@ insertModelDesignSettings <- function(
     splitSettingId = splitId, # changed from trainingId
     featureEngineeringSettingId = FESetId,
     tidyCovariatesSettingId = tidySetId,
+    hyperparameterSettingId = hyperparameterSetId,
     tablePrefix = databaseSchemaSettings$tablePrefix,
     tempEmulationSchema = databaseSchemaSettings$tempEmulationSchema
   )
@@ -247,6 +262,7 @@ addModelDesign <- function(
     splitSettingId,
     featureEngineeringSettingId,
     tidyCovariatesSettingId,
+    hyperparameterSettingId,
     tempEmulationSchema = getOption("sqlRenderTempEmulationSchema")) {
   if (is.null(targetId)) {
     stop("targetId is null")
@@ -282,6 +298,9 @@ addModelDesign <- function(
   if (is.null(tidyCovariatesSettingId)) {
     stop("tidyCovariatesSettingId is null")
   }
+  if (is.null(hyperparameterSettingId)) {
+    stop("hyperparameterSettingId is null")
+  }
 
   # process json to make it ordered...
   # TODO
@@ -303,7 +322,8 @@ addModelDesign <- function(
       "sample_setting_id",
       "split_setting_id",
       "feature_engineering_setting_id",
-      "tidy_covariates_setting_id"
+      "tidy_covariates_setting_id",
+      "hyperparameter_setting_id"
     ),
     values = c(
       targetId,
@@ -316,7 +336,8 @@ addModelDesign <- function(
       sampleSettingId,
       splitSettingId,
       featureEngineeringSettingId,
-      tidyCovariatesSettingId
+      tidyCovariatesSettingId,
+      hyperparameterSettingId
     ),
     tempEmulationSchema = tempEmulationSchema
   )
@@ -334,7 +355,8 @@ addModelDesign <- function(
     sample_setting_id,
     split_setting_id,
     feature_engineering_setting_id,
-    tidy_covariates_setting_id
+    tidy_covariates_setting_id,
+    hyperparameter_setting_id
     ) VALUES
   (
   @target_id,
@@ -347,7 +369,8 @@ addModelDesign <- function(
   @sample_setting_id,
   @split_setting_id,
   @feature_engineering_setting_id,
-  @tidy_covariates_setting_id
+  @tidy_covariates_setting_id,
+  @hyperparameter_setting_id
     )"
     sql <- SqlRender::render(
       sql,
@@ -363,6 +386,7 @@ addModelDesign <- function(
       split_setting_id = splitSettingId,
       feature_engineering_setting_id = featureEngineeringSettingId,
       tidy_covariates_setting_id = tidyCovariatesSettingId,
+      hyperparameter_setting_id = hyperparameterSettingId,
       string_to_append = tablePrefix
     )
     sql <- SqlRender::translate(sql,
@@ -389,7 +413,8 @@ addModelDesign <- function(
         "sample_setting_id",
         "split_setting_id",
         "feature_engineering_setting_id",
-        "tidy_covariates_setting_id"
+        "tidy_covariates_setting_id",
+        "hyperparameter_setting_id"
       ),
       values = c(
         targetId,
@@ -402,7 +427,8 @@ addModelDesign <- function(
         sampleSettingId,
         splitSettingId,
         featureEngineeringSettingId,
-        tidyCovariatesSettingId
+        tidyCovariatesSettingId,
+        hyperparameterSettingId
       ),
       tempEmulationSchema = tempEmulationSchema
     )
@@ -1013,6 +1039,69 @@ addSplitSettings <- function(
     )
   } else {
     ParallelLogger::logInfo("Split setting exists")
+  }
+
+  return(jsonId)
+}
+
+addHyperparameterSetting <- function(
+    conn,
+    resultSchema,
+    targetDialect,
+    tablePrefix = "",
+    json,
+    tempEmulationSchema = getOption("sqlRenderTempEmulationSchema")) {
+  if (!inherits(x = json, what = "character")) {
+    json <- orderJson(json) # to ensure attributes are alphabetic order
+    json <- ParallelLogger::convertSettingsToJson(json)
+    json <- as.character(json) # now convert to character
+  }
+
+  jsonId <- checkJson(
+    conn = conn,
+    resultSchema = resultSchema,
+    tablePrefix = tablePrefix,
+    targetDialect = targetDialect,
+    tableName = "hyperparameter_settings",
+    jsonColumnName = "hyperparameterSettingsJson",
+    id = "hyperparameterSettingId",
+    json = json,
+    tempEmulationSchema = tempEmulationSchema
+  )
+
+  if (is.null(jsonId)) {
+    ParallelLogger::logInfo("Adding new hyperparameter settings")
+
+    data <- data.frame(
+      hyperparameterSettingsJson = json
+    )
+
+    DatabaseConnector::insertTable(
+      connection = conn,
+      databaseSchema = resultSchema,
+      tableName = paste0(tablePrefix, "hyperparameter_settings"),
+      data = data,
+      dropTableIfExists = FALSE,
+      createTable = FALSE,
+      tempTable = FALSE,
+      progressBar = TRUE,
+      camelCaseToSnakeCase = TRUE,
+      tempEmulationSchema = tempEmulationSchema
+    )
+
+    jsonId <- checkJson(
+      conn = conn,
+      resultSchema = resultSchema,
+      tablePrefix = tablePrefix,
+      targetDialect = targetDialect,
+      tableName = "hyperparameter_settings",
+      jsonColumnName = "hyperparameterSettingsJson",
+      id = "hyperparameterSettingId",
+      json = json,
+      tempEmulationSchema = tempEmulationSchema
+    )
+  } else {
+    ParallelLogger::logInfo("Hyperparameter setting exists")
   }
 
   return(jsonId)

--- a/inst/settings/resultsDataModelSpecification.csv
+++ b/inst/settings/resultsDataModelSpecification.csv
@@ -33,6 +33,8 @@ covariate_settings,covariate_settings_json,text,Yes,No,No,No,the json with the s
 model_settings,model_setting_id,int,Yes,Yes,No,No,a unique identifier for the model settings
 model_settings,model_type,varchar,No,No,No,No,the type of model 
 model_settings,model_settings_json,varchar,Yes,No,No,No,the json with the settings
+hyperparameter_settings,hyperparameter_setting_id,int,Yes,Yes,No,No,a unique identifier for the hyperparameter settings
+hyperparameter_settings,hyperparameter_settings_json,text,Yes,No,No,No,the json with the settings
 split_settings,split_setting_id,int,Yes,Yes,No,No,a unique identifier for the split settings
 split_settings,split_settings_json,text,Yes,No,No,No,the json with the settings
 plp_data_settings,plp_data_setting_id,int,Yes,Yes,No,No,a unique identifier for the plp data settings
@@ -55,6 +57,7 @@ model_designs,sample_setting_id,int,Yes,No,No,No,the  identifier for the sample 
 model_designs,split_setting_id,int,Yes,No,No,No,the  identifier for the split setting
 model_designs,feature_engineering_setting_id,int,Yes,No,No,No,the  identifier for the feature engineering setting
 model_designs,tidy_covariates_setting_id,int,Yes,No,No,No,the  identifier for the tidy covariate setting
+model_designs,hyperparameter_setting_id,int,Yes,No,No,No,the  identifier for the hyperparameter setting
 diagnostics,diagnostic_id,int,Yes,Yes,No,No,the unique identifier for the diagnostic results
 diagnostics,model_design_id,int,Yes,No,No,No,the identifier for the model design
 diagnostics,database_id,int,Yes,No,No,No,the identifier for the database

--- a/inst/sql/postgresql/migrations/Migration_2-add_hyperparameter_settings.sql
+++ b/inst/sql/postgresql/migrations/Migration_2-add_hyperparameter_settings.sql
@@ -1,0 +1,25 @@
+-- Database migration to persist hyperparameter settings as model design settings
+
+{DEFAULT @table_prefix = ''}
+
+CREATE TABLE IF NOT EXISTS @database_schema.@table_prefixhyperparameter_settings (
+    hyperparameter_setting_id int GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+    hyperparameter_settings_json text NOT NULL
+);
+
+INSERT INTO @database_schema.@table_prefixhyperparameter_settings (hyperparameter_settings_json)
+SELECT '{}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM @database_schema.@table_prefixhyperparameter_settings
+);
+
+ALTER TABLE @database_schema.@table_prefixmodel_designs
+ADD COLUMN IF NOT EXISTS hyperparameter_setting_id int;
+
+UPDATE @database_schema.@table_prefixmodel_designs md
+SET hyperparameter_setting_id = hp.hyperparameter_setting_id
+FROM (
+  SELECT MIN(hyperparameter_setting_id) AS hyperparameter_setting_id
+  FROM @database_schema.@table_prefixhyperparameter_settings
+) hp
+WHERE md.hyperparameter_setting_id IS NULL;

--- a/inst/sql/sql_server/migrations/Migration_2-add_hyperparameter_settings.sql
+++ b/inst/sql/sql_server/migrations/Migration_2-add_hyperparameter_settings.sql
@@ -1,0 +1,35 @@
+-- Database migration to persist hyperparameter settings as model design settings
+
+{DEFAULT @table_prefix = ''}
+
+IF OBJECT_ID('@database_schema.@table_prefixhyperparameter_settings', 'U') IS NULL
+BEGIN
+  CREATE TABLE @database_schema.@table_prefixhyperparameter_settings (
+      hyperparameter_setting_id int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+      hyperparameter_settings_json VARCHAR(MAX) NOT NULL
+  );
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM @database_schema.@table_prefixhyperparameter_settings
+)
+BEGIN
+  INSERT INTO @database_schema.@table_prefixhyperparameter_settings (hyperparameter_settings_json)
+  VALUES ('{}');
+END;
+
+IF COL_LENGTH('@database_schema.@table_prefixmodel_designs', 'hyperparameter_setting_id') IS NULL
+BEGIN
+  ALTER TABLE @database_schema.@table_prefixmodel_designs
+  ADD hyperparameter_setting_id int;
+END;
+
+UPDATE md
+SET md.hyperparameter_setting_id = hp.hyperparameter_setting_id
+FROM @database_schema.@table_prefixmodel_designs md
+CROSS JOIN (
+  SELECT MIN(hyperparameter_setting_id) AS hyperparameter_setting_id
+  FROM @database_schema.@table_prefixhyperparameter_settings
+) hp
+WHERE md.hyperparameter_setting_id IS NULL;

--- a/inst/sql/sqlite/migrations/Migration_2-add_hyperparameter_settings.sql
+++ b/inst/sql/sqlite/migrations/Migration_2-add_hyperparameter_settings.sql
@@ -1,0 +1,24 @@
+-- Database migration to persist hyperparameter settings as model design settings
+
+{DEFAULT @table_prefix = ''}
+
+CREATE TABLE IF NOT EXISTS @database_schema.@table_prefixhyperparameter_settings (
+    hyperparameter_setting_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    hyperparameter_settings_json text NOT NULL
+);
+
+INSERT INTO @database_schema.@table_prefixhyperparameter_settings (hyperparameter_settings_json)
+SELECT '{}'
+WHERE NOT EXISTS (
+    SELECT 1 FROM @database_schema.@table_prefixhyperparameter_settings
+);
+
+ALTER TABLE @database_schema.@table_prefixmodel_designs
+ADD COLUMN hyperparameter_setting_id int;
+
+UPDATE @database_schema.@table_prefixmodel_designs
+SET hyperparameter_setting_id = (
+    SELECT MIN(hyperparameter_setting_id)
+    FROM @database_schema.@table_prefixhyperparameter_settings
+)
+WHERE hyperparameter_setting_id IS NULL;

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -143,6 +143,11 @@ test_that("addHyperparameterSetting deduplicates identical settings json", {
     search = "grid"
   )
 
+  rowCountBefore <- DatabaseConnector::querySql(
+    conn,
+    "select count(*) as n from main.hyperparameter_settings;"
+  )
+
   firstId <- PatientLevelPrediction:::addHyperparameterSetting(
     conn = conn,
     resultSchema = "main",
@@ -162,11 +167,11 @@ test_that("addHyperparameterSetting deduplicates identical settings json", {
 
   expect_equal(firstId, secondId)
 
-  res <- DatabaseConnector::querySql(
+  rowCountAfter <- DatabaseConnector::querySql(
     conn,
     "select count(*) as n from main.hyperparameter_settings;"
   )
-  expect_equal(res$n[1], 2)
+  expect_equal(rowCountAfter$n[1], rowCountBefore$n[1] + 1)
 })
 
 test_that("insertModelDesignInDatabase differentiates model_design_id by hyperparameter settings", {

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -114,3 +114,154 @@ test_that("addModelSetting derives modelType from supported paths and sanitizes 
     expect_equal(res$modelType[1], expectedModelTypes[i])
   }
 })
+
+test_that("addHyperparameterSetting deduplicates identical settings json", {
+  skip_if_not_installed("RSQLite")
+
+  sqliteFile <- file.path(tempdir(), "plp-hyperparameter-setting.sqlite")
+  if (file.exists(sqliteFile)) unlink(sqliteFile)
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteFile
+  )
+
+  PatientLevelPrediction::createPlpResultTables(
+    connectionDetails = connectionDetails,
+    targetDialect = "sqlite",
+    resultSchema = "main",
+    deleteTables = TRUE,
+    createTables = TRUE,
+    tablePrefix = "",
+    tempEmulationSchema = NULL
+  )
+
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  hyperparameterSettings <- PatientLevelPrediction::createHyperparameterSettings(
+    search = "grid"
+  )
+
+  firstId <- PatientLevelPrediction:::addHyperparameterSetting(
+    conn = conn,
+    resultSchema = "main",
+    targetDialect = "sqlite",
+    tablePrefix = "",
+    json = hyperparameterSettings,
+    tempEmulationSchema = NULL
+  )
+  secondId <- PatientLevelPrediction:::addHyperparameterSetting(
+    conn = conn,
+    resultSchema = "main",
+    targetDialect = "sqlite",
+    tablePrefix = "",
+    json = hyperparameterSettings,
+    tempEmulationSchema = NULL
+  )
+
+  expect_equal(firstId, secondId)
+
+  res <- DatabaseConnector::querySql(
+    conn,
+    "select count(*) as n from main.hyperparameter_settings;"
+  )
+  expect_equal(res$n[1], 2)
+})
+
+test_that("insertModelDesignInDatabase differentiates model_design_id by hyperparameter settings", {
+  skip_if_not_installed("RSQLite")
+
+  sqliteFile <- file.path(tempdir(), "plp-model-design-hyperparameter.sqlite")
+  if (file.exists(sqliteFile)) unlink(sqliteFile)
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteFile
+  )
+
+  PatientLevelPrediction::createPlpResultTables(
+    connectionDetails = connectionDetails,
+    targetDialect = "sqlite",
+    resultSchema = "main",
+    deleteTables = TRUE,
+    createTables = TRUE,
+    tablePrefix = "",
+    tempEmulationSchema = NULL
+  )
+
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  databaseSchemaSettings <- PatientLevelPrediction::createDatabaseSchemaSettings(
+    resultSchema = "main",
+    targetDialect = "sqlite",
+    tempEmulationSchema = NULL
+  )
+
+  baseModelSettings <- PatientLevelPrediction::setLassoLogisticRegression(seed = 42)
+  cohortDefinitions <- data.frame(
+    cohortName = c("target", "outcome"),
+    cohortId = c(1, 2),
+    json = c("{}", "{}"),
+    stringsAsFactors = FALSE
+  )
+
+  modelDesignGrid <- PatientLevelPrediction::createModelDesign(
+    targetId = 1,
+    outcomeId = 2,
+    modelSettings = baseModelSettings,
+    hyperparameterSettings = PatientLevelPrediction::createHyperparameterSettings(
+      search = "grid"
+    )
+  )
+  modelDesignRandom <- PatientLevelPrediction::createModelDesign(
+    targetId = 1,
+    outcomeId = 2,
+    modelSettings = baseModelSettings,
+    hyperparameterSettings = PatientLevelPrediction::createHyperparameterSettings(
+      search = "random",
+      sampleSize = 1,
+      randomSeed = 42
+    )
+  )
+
+  modelDesignGridId <- PatientLevelPrediction:::insertModelDesignInDatabase(
+    object = modelDesignGrid,
+    conn = conn,
+    databaseSchemaSettings = databaseSchemaSettings,
+    cohortDefinitions = cohortDefinitions
+  )
+  modelDesignRandomId <- PatientLevelPrediction:::insertModelDesignInDatabase(
+    object = modelDesignRandom,
+    conn = conn,
+    databaseSchemaSettings = databaseSchemaSettings,
+    cohortDefinitions = cohortDefinitions
+  )
+  modelDesignGridIdRepeat <- PatientLevelPrediction:::insertModelDesignInDatabase(
+    object = modelDesignGrid,
+    conn = conn,
+    databaseSchemaSettings = databaseSchemaSettings,
+    cohortDefinitions = cohortDefinitions
+  )
+
+  expect_equal(modelDesignGridId, modelDesignGridIdRepeat)
+  expect_false(modelDesignGridId == modelDesignRandomId)
+
+  modelDesignRows <- DatabaseConnector::querySql(
+    conn,
+    paste0(
+      "select model_design_id as modelDesignId, ",
+      "hyperparameter_setting_id as hyperparameterSettingId ",
+      "from main.model_designs where model_design_id in (",
+      modelDesignGridId, ", ", modelDesignRandomId, ");"
+    )
+  )
+  expect_equal(length(unique(modelDesignRows$hyperparameterSettingId)), 2)
+
+  hyperparameterRows <- DatabaseConnector::querySql(
+    conn,
+    "select count(*) as n from main.hyperparameter_settings;"
+  )
+  expect_gte(hyperparameterRows$n[1], 2)
+})


### PR DESCRIPTION
## Summary
- add hyperparameter_settings as a dedicated settings table and store hyperparameter JSON there
- add hyperparameter_setting_id to model_designs insertion/deduplication so different hyperparameter settings produce different model_design_id
- add DB migrations (sqlite/sql server/postgresql) to create/backfill the new table+column for existing schemas
- update CSV import/model design reconstruction to read hyperparameter_setting_id when present (backward compatible)
- update results data model specification and add focused tests for new behavior

## Why
The reviewer asked to store hyperparameter settings as model design settings (instead of only in train_details) so model design identity reflects hyperparameter changes.

## Testing
- Rscript -e "devtools::test(filter='UploadToDatabaseModelDesign')"
- Rscript -e "devtools::test(filter='UploadToDatabase')"
- GitHub Actions R-CMD-check passed on this branch

## Stacked PR
This PR is stacked on top of #628 (base: issue-620).
