### PR TITLE
feat(upload): persist modelName in model settings

### DIFF
--- a/R/uploadToDatabaseModelDesign.R
+++ b/R/uploadToDatabaseModelDesign.R
@@ -635,36 +635,68 @@ addCovariateSetting <- function(conn, resultSchema, targetDialect,
 }
 
 
+extractModelSettingField <- function(json, fieldName, missingValue = NA_character_) {
+  candidate <- NULL
+  if (is.list(json)) {
+    if (!is.null(json$settings) && is.list(json$settings)) {
+      candidate <- json$settings[[fieldName]]
+    }
+
+    if (is.null(candidate) && !is.null(json$param)) {
+      paramSettings <- attr(json$param, "settings")
+      if (is.list(paramSettings)) {
+        candidate <- paramSettings[[fieldName]]
+      }
+    }
+  }
+
+  if (is.null(candidate) || is.list(candidate) || length(candidate) == 0) {
+    return(missingValue)
+  }
+
+  candidate <- as.character(candidate)[1]
+  if (is.na(candidate) || !nzchar(trimws(candidate))) {
+    return(missingValue)
+  }
+
+  trimws(candidate)
+}
+
+hasModelSettingColumn <- function(conn,
+                                  resultSchema,
+                                  targetDialect,
+                                  tablePrefix = "",
+                                  columnName,
+                                  tempEmulationSchema = getOption("sqlRenderTempEmulationSchema")) {
+  sql <- "SELECT * FROM @result_schema.@table_name WHERE 1 = 0;"
+  sql <- SqlRender::render(
+    sql,
+    result_schema = resultSchema,
+    table_name = paste0(tablePrefix, "model_settings")
+  )
+  sql <- SqlRender::translate(
+    sql,
+    targetDialect = targetDialect,
+    tempEmulationSchema = tempEmulationSchema
+  )
+  result <- DatabaseConnector::querySql(conn = conn, sql = sql)
+  tolower(columnName) %in% tolower(colnames(result))
+}
+
 addModelSetting <- function(conn, resultSchema, targetDialect,
                             tablePrefix = "",
                             json,
                             tempEmulationSchema = getOption("sqlRenderTempEmulationSchema")) {
-  modelType <- "NULL"
-  if (is.list(json)) {
-    modelTypeCandidate <- NULL
-
-    if (!is.null(json$settings) && is.list(json$settings)) {
-      modelTypeCandidate <- json$settings$modelType
-    }
-
-    if (is.null(modelTypeCandidate) && !is.null(json$param)) {
-      paramSettings <- attr(json$param, "settings")
-      if (is.list(paramSettings)) {
-        modelTypeCandidate <- paramSettings$modelType
-      }
-    }
-
-    if (!is.null(modelTypeCandidate)) {
-      if (is.list(modelTypeCandidate) || length(modelTypeCandidate) == 0) {
-        modelType <- "NULL"
-      } else {
-        modelType <- as.character(modelTypeCandidate)[1]
-        if (is.na(modelType) || !nzchar(modelType)) {
-          modelType <- "NULL"
-        }
-      }
-    }
-  }
+  modelType <- extractModelSettingField(
+    json = json,
+    fieldName = "modelType",
+    missingValue = "NULL"
+  )
+  modelName <- extractModelSettingField(
+    json = json,
+    fieldName = "modelName",
+    missingValue = NA_character_
+  )
   # process json to make it ordered...
   # make sure the json has been converted
   if (!inherits(x = json, what = "character")) {
@@ -688,10 +720,23 @@ addModelSetting <- function(conn, resultSchema, targetDialect,
   if (is.null(jsonId)) {
     ParallelLogger::logInfo("Adding new model settings")
 
+    hasModelNameColumn <- hasModelSettingColumn(
+      conn = conn,
+      resultSchema = resultSchema,
+      targetDialect = targetDialect,
+      tablePrefix = tablePrefix,
+      columnName = "model_name",
+      tempEmulationSchema = tempEmulationSchema
+    )
+
     data <- data.frame(
       modelType = modelType,
       modelSettingsJson = json
     )
+    if (hasModelNameColumn) {
+      data$modelName <- modelName
+      data <- data[c("modelType", "modelName", "modelSettingsJson")]
+    }
     DatabaseConnector::insertTable(
       connection = conn,
       databaseSchema = resultSchema,

--- a/inst/sql/postgresql/migrations/Migration_3-add_model_name.sql
+++ b/inst/sql/postgresql/migrations/Migration_3-add_model_name.sql
@@ -1,0 +1,21 @@
+-- Database migration to persist model algorithm name in model settings
+
+{DEFAULT @table_prefix = ''}
+
+ALTER TABLE @database_schema.@table_prefixmodel_settings
+ADD COLUMN IF NOT EXISTS model_name VARCHAR(255);
+
+UPDATE @database_schema.@table_prefixmodel_settings ms
+SET model_name = src.model_name
+FROM (
+  SELECT md.model_setting_id,
+         MIN(m.model_type) AS model_name
+  FROM @database_schema.@table_prefixmodel_designs md
+  INNER JOIN @database_schema.@table_prefixmodels m
+    ON md.model_design_id = m.model_design_id
+  WHERE m.model_type IS NOT NULL
+    AND BTRIM(m.model_type) <> ''
+  GROUP BY md.model_setting_id
+) src
+WHERE ms.model_setting_id = src.model_setting_id
+  AND (ms.model_name IS NULL OR BTRIM(ms.model_name) = '');

--- a/inst/sql/sql_server/migrations/Migration_3-add_model_name.sql
+++ b/inst/sql/sql_server/migrations/Migration_3-add_model_name.sql
@@ -1,0 +1,26 @@
+-- Database migration to persist model algorithm name in model settings
+
+{DEFAULT @table_prefix = ''}
+
+IF COL_LENGTH('@database_schema.@table_prefixmodel_settings', 'model_name') IS NULL
+BEGIN
+  ALTER TABLE @database_schema.@table_prefixmodel_settings
+  ADD model_name VARCHAR(255);
+END;
+
+UPDATE ms
+SET ms.model_name = src.model_name
+FROM @database_schema.@table_prefixmodel_settings ms
+INNER JOIN (
+  SELECT md.model_setting_id,
+         MIN(m.model_type) AS model_name
+  FROM @database_schema.@table_prefixmodel_designs md
+  INNER JOIN @database_schema.@table_prefixmodels m
+    ON md.model_design_id = m.model_design_id
+  WHERE m.model_type IS NOT NULL
+    AND LTRIM(RTRIM(m.model_type)) <> ''
+  GROUP BY md.model_setting_id
+) src
+  ON ms.model_setting_id = src.model_setting_id
+WHERE ms.model_name IS NULL
+   OR LTRIM(RTRIM(ms.model_name)) = '';

--- a/inst/sql/sqlite/migrations/Migration_3-add_model_name.sql
+++ b/inst/sql/sqlite/migrations/Migration_3-add_model_name.sql
@@ -1,0 +1,19 @@
+-- Database migration to persist model algorithm name in model settings
+
+{DEFAULT @table_prefix = ''}
+
+ALTER TABLE @database_schema.@table_prefixmodel_settings
+ADD COLUMN model_name VARCHAR(255);
+
+UPDATE @database_schema.@table_prefixmodel_settings
+SET model_name = (
+  SELECT MIN(m.model_type)
+  FROM @database_schema.@table_prefixmodel_designs md
+  INNER JOIN @database_schema.@table_prefixmodels m
+    ON md.model_design_id = m.model_design_id
+  WHERE md.model_setting_id = @database_schema.@table_prefixmodel_settings.model_setting_id
+    AND m.model_type IS NOT NULL
+    AND TRIM(m.model_type) <> ''
+)
+WHERE model_name IS NULL
+   OR TRIM(model_name) = '';

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -38,13 +38,15 @@ test_that("addModelSetting handles minimal modelSettings objects", {
 
   res <- DatabaseConnector::querySql(
     conn,
-    "select model_type as modelType from main.model_settings;"
+    "select model_type as modelType, model_name as modelName from main.model_settings;"
   )
   expect_true("modelType" %in% names(res))
+  expect_true("modelName" %in% names(res))
   expect_true(any(res$modelType == "NULL"))
+  expect_true(any(is.na(res$modelName)))
 })
 
-test_that("addModelSetting derives modelType from supported paths and sanitizes invalid values", {
+test_that("addModelSetting derives modelType/modelName and sanitizes invalid values", {
   skip_if_not_installed("RSQLite")
 
   sqliteFile <- file.path(tempdir(), "plp-model-setting-branches.sqlite")
@@ -69,18 +71,33 @@ test_that("addModelSetting derives modelType from supported paths and sanitizes 
   on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
 
   settingsModelType <- list(
-    settings = list(modelType = "binary"),
+    settings = list(modelType = "binary", modelName = "xgboost"),
     model = "from-settings"
   )
   fallbackModelType <- list(
     settings = list(),
-    param = structure(list(alpha = 0.1), settings = list(modelType = "survival")),
+    param = structure(
+      list(alpha = 0.1),
+      settings = list(modelType = "survival", modelName = "lightGBM")
+    ),
     model = "from-param-settings"
   )
-  listModelType <- list(settings = list(modelType = list("bad")), model = "list-model-type")
-  emptyModelType <- list(settings = list(modelType = character(0)), model = "empty-model-type")
-  blankModelType <- list(settings = list(modelType = ""), model = "blank-model-type")
-  naModelType <- list(settings = list(modelType = NA_character_), model = "na-model-type")
+  listModelType <- list(
+    settings = list(modelType = list("bad"), modelName = list("bad")),
+    model = "list-model-type"
+  )
+  emptyModelType <- list(
+    settings = list(modelType = character(0), modelName = character(0)),
+    model = "empty-model-type"
+  )
+  blankModelType <- list(
+    settings = list(modelType = "", modelName = ""),
+    model = "blank-model-type"
+  )
+  naModelType <- list(
+    settings = list(modelType = NA_character_, modelName = NA_character_),
+    model = "na-model-type"
+  )
   charJson <- '{"settings":{"modelType":"ignored"}}'
 
   inputs <- list(
@@ -93,6 +110,7 @@ test_that("addModelSetting derives modelType from supported paths and sanitizes 
     charJson
   )
   expectedModelTypes <- c("binary", "survival", "NULL", "NULL", "NULL", "NULL", "NULL")
+  expectedModelNames <- c("xgboost", "lightGBM", NA, NA, NA, NA, NA)
 
   for (i in seq_along(inputs)) {
     modelSettingId <- PatientLevelPrediction:::addModelSetting(
@@ -107,12 +125,76 @@ test_that("addModelSetting derives modelType from supported paths and sanitizes 
     res <- DatabaseConnector::querySql(
       conn,
       paste0(
-        "select model_type as modelType from main.model_settings ",
+        "select model_type as modelType, model_name as modelName ",
+        "from main.model_settings ",
         "where model_setting_id = ", modelSettingId, ";"
       )
     )
     expect_equal(res$modelType[1], expectedModelTypes[i])
+    expect_equal(res$modelName[1], expectedModelNames[i])
   }
+})
+
+test_that("Migration_3 adds model_name and backfills from models table", {
+  skip_if_not_installed("RSQLite")
+
+  sqliteFile <- file.path(tempdir(), "plp-model-name-migration.sqlite")
+  if (file.exists(sqliteFile)) unlink(sqliteFile)
+
+  connectionDetails <- DatabaseConnector::createConnectionDetails(
+    dbms = "sqlite",
+    server = sqliteFile
+  )
+  conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
+  on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
+
+  DatabaseConnector::executeSql(conn, paste(
+    "create table main.model_settings (",
+    "  model_setting_id INTEGER PRIMARY KEY AUTOINCREMENT,",
+    "  model_type VARCHAR(50),",
+    "  model_settings_json TEXT",
+    ");",
+    "create table main.model_designs (",
+    "  model_design_id INTEGER PRIMARY KEY AUTOINCREMENT,",
+    "  model_setting_id int",
+    ");",
+    "create table main.models (",
+    "  model_id INTEGER PRIMARY KEY AUTOINCREMENT,",
+    "  model_design_id int,",
+    "  model_type VARCHAR(50)",
+    ");"
+  ))
+
+  DatabaseConnector::executeSql(
+    conn,
+    "insert into main.model_settings (model_type, model_settings_json) values ('binary', '{}');"
+  )
+  DatabaseConnector::executeSql(
+    conn,
+    "insert into main.model_designs (model_setting_id) values (1);"
+  )
+  DatabaseConnector::executeSql(
+    conn,
+    "insert into main.models (model_design_id, model_type) values (1, 'xgboost');"
+  )
+
+  migrationSql <- SqlRender::loadRenderTranslateSql(
+    sqlFilename = "migrations/Migration_3-add_model_name.sql",
+    packageName = "PatientLevelPrediction",
+    dbms = "sqlite",
+    database_schema = "main",
+    table_prefix = ""
+  )
+  DatabaseConnector::executeSql(conn, migrationSql)
+
+  columnInfo <- DatabaseConnector::querySql(conn, "PRAGMA table_info(model_settings);")
+  expect_true("model_name" %in% columnInfo$name)
+
+  migrated <- DatabaseConnector::querySql(
+    conn,
+    "select model_name as modelName from main.model_settings where model_setting_id = 1;"
+  )
+  expect_equal(migrated$modelName[1], "xgboost")
 })
 
 test_that("addHyperparameterSetting deduplicates identical settings json", {


### PR DESCRIPTION
## Summary
- add Migration_3 for sql server/sqlite/postgresql to add model_name to model_settings
- backfill model_settings.model_name from existing models.model_type via model design linkage
- update addModelSetting() to extract and persist both modelType and modelName
- keep backward compatibility: only write model_name when the target schema has that column
- add tests covering modelName persistence and migration backfill

## Why
Downstream UI/query layers use algorithm naming (modelName), while current schema stores this in a legacy overloaded field (models.model_type). This migration introduces an explicit field in model_settings so algorithm metadata is available in the correct settings table.

## Testing
- Rscript -e "devtools::test(filter='UploadToDatabaseModelDesign')"
- Rscript -e "devtools::test(filter='UploadToDatabase')"

## Stack
- Base: #631 (issue-620-model-design-hyperparams)
