### PR TITLE
fix: dynamically look up sex covariateId in createSimulationProfile (…

### DIFF
--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -48,19 +48,33 @@ createSimulationProfile <- function(plpData) {
     dplyr::collect()
 
   outcomeRate <- nrow(plpData$outcomes) / nrow(plpData$cohorts)
+
+  # Look up actual sex covariateId from data (OMOP: 8507=male, 8532=female).
+  # FeatureExtraction stores gender as conceptId * 1000 + analysisId (e.g. 8507001),
+  # so the raw concept IDs alone will not match via inner_join in predictCyclopsType.
+  allCovIds <- as.numeric(names(covariatePrevalence))
+  sexCovIds <- allCovIds[floor(allCovIds / 1000) %in% c(8507L, 8532L) |
+                           allCovIds %in% c(8507L, 8532L)]
+  sexCoefName <- if (length(sexCovIds) > 0) as.character(sexCovIds[1]) else NULL
+
   writeLines("Fitting outcome model(s)")
   outcomeModels <- vector("list", length(plpData$metaData$databaseDetails$outcomeIds))
   for (i in seq_along(plpData$metaData$databaseDetails$outcomeIds)) {
-   coefficients <- c("(Intercept)" = -2, 
-       "1002" = 0.04,  # age
-       "8532" = 0.5,   # male 
-       "81893102" = 0.5, # ulcerative colitis
-       "4266809102" = 1.0, # Diverticular disease
-       "4310024102" = 1.5, #Angiodysplasia of stomach
-       "1112807402" = 0.7, # Aspirin
-       "1177480402" = 0.6, # Ibuprofen
-       "439777102" = 0.8)  # Anemia
-    outcomeModels[[i]] <- coefficients
+    baseCoefficients <- c(
+      "(Intercept)" = -2,
+      "1002" = 0.04,  # age
+      "81893102" = 0.5, # ulcerative colitis
+      "4266809102" = 1.0, # Diverticular disease
+      "4310024102" = 1.5, # Angiodysplasia of stomach
+      "1112807402" = 0.7, # Aspirin
+      "1177480402" = 0.6, # Ibuprofen
+      "439777102" = 0.8  # Anemia
+    )
+    if (!is.null(sexCoefName)) {
+      # Insert sex coefficient using the actual covariateId from the data
+      baseCoefficients <- c(baseCoefficients, stats::setNames(0.5, sexCoefName))
+    }
+    outcomeModels[[i]] <- baseCoefficients
   }
 
   timeMax <- max(plpData$outcomes$daysToEvent)

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -48,7 +48,7 @@ test_that("create simulation profile works", {
       analysisRef = analysisRef
     )
   )
-  simProfile <- createSimulationProfile(simData)
+  simProfile <- PatientLevelPrediction:::createSimulationProfile(simData)
   expect_type(simProfile, "list")
   expect_s3_class(simProfile, "plpDataSimulationProfile")
   expect_true(all(c(
@@ -71,10 +71,52 @@ test_that("create simulation profile works", {
     length(simProfile$outcomeModels),
     length(metaData$databaseDetails$outcomeIds)
   )
+  # sex covariate (8532 raw concept ID) should be picked up and used in model
   expect_true(all(list("(Intercept)" = -2.0, "1002" = 0.04, "8532" = 0.50)
   %in% simProfile$outcomeModels[[1]]))
   expect_equal(simProfile$metaData, metaData)
   expect_equal(simProfile$covariateRef, as.data.frame(covariateRef))
+})
+
+test_that("createSimulationProfile uses FeatureExtraction-format sex covariateId", {
+  # FeatureExtraction stores gender as conceptId * 1000 + analysisId, e.g. 8532001
+  # The outcome model should reference this full covariateId, not the raw concept ID
+  cohorts <- data.frame(rowId = 1:10, subjectId = 1:10, targetId = rep(1, 10))
+  femaleCovId <- 8532001L  # 8532 * 1000 + 1 (analysisId = 1)
+  covariates <- data.frame(
+    rowId = c(1:10, 1:10),
+    covariateId = c(rep(1002L, 10), rep(femaleCovId, 10)),
+    covariateValue = c(stats::runif(10), rep(1, 10))
+  )
+  covariateRef <- data.frame(
+    covariateId = c(1002L, femaleCovId),
+    covariateName = c("age", "gender = FEMALE"),
+    analysisId = c(2L, 1L)
+  )
+  analysisRef <- data.frame(
+    analysisId = c(1L, 2L),
+    analysisName = c("DemographicsGender", "DemographicsAge"),
+    isBinary = c("Y", "N")
+  )
+  outcomes <- data.frame(rowId = 1:5, daysToEvent = c(10, 20, 30, 40, 50))
+  metaData <- list(databaseDetails = list(outcomeIds = 1L))
+  simData <- list(
+    cohorts = cohorts,
+    outcomes = outcomes,
+    metaData = metaData,
+    covariateData = list(
+      covariates = covariates,
+      covariateRef = covariateRef,
+      analysisRef = analysisRef
+    )
+  )
+  simProfile <- PatientLevelPrediction:::createSimulationProfile(simData)
+  model <- simProfile$outcomeModels[[1]]
+  # The outcome model must contain the full FeatureExtraction covariateId (8532001)
+  expect_true(as.character(femaleCovId) %in% names(model),
+    label = "sex covariateId with analysisId suffix is included in outcome model")
+  # The raw concept ID alone should NOT be used when the full ID is available
+  expect_equal(model[[as.character(femaleCovId)]], 0.5)
 })
 
 test_that("simulatePlpData works", {


### PR DESCRIPTION
## Fix: dynamically look up sex covariateId in createSimulationProfile

Closes #640

### Problem
`createSimulationProfile()` hardcodes `"8532"` as the sex covariate coefficient name. However, FeatureExtraction stores gender as `conceptId * 1000 + analysisId` (e.g. `8532001`). The inner join in `predictCyclopsType` never matches `"8532"` against `"8532001"`, so sex is silently excluded from all simulations.

Additionally, the comment said `# male` but 8532 is the OMOP concept for FEMALE.

### Fix
Instead of hardcoding `"8532"`, scan `covariatePrevalence` for covariate IDs matching gender concepts (8507/8532) in either raw or FeatureExtraction format (`floor(id/1000)`). Use the actual ID found in the data. If no sex covariate exists, omit gracefully.

### Note
If both male (8507) and female (8532) covariates exist in the data, the first match is used. This is sufficient for simulation purposes since only one coefficient is needed to model the sex effect.

### Tests
Added test verifying that FeatureExtraction-format covariateId (8532001) is correctly picked up. Existing simulation tests pass (43/43).