### PR TITLE
Fix simulation outcome covariate validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ PatientLevelPrediction 6.6.0
 - Persisted hyperparameter settings and model names in the results data model to improve downstream model identification and viewing (#633, #632).
 
 ## Bug fixes
+- Fixed simulation profile outcome models so generated coefficients only reference covariates available in the profile, added support for user-supplied outcome models, and invalid custom profiles now fail early instead of silently dropping outcome signal.
 - Improved upload of hyperparameter metadata and robustness of model settings persistence for database viewers and downstream tools (#628, #623).
 - Ensured existing GLM and scikit-learn model settings retain model identity so uploads generate distinct model design records (#614).
 - Fixed evaluation when outcomes are single-class (#624).

--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -16,13 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#' Create simulation profile using eunomia data and a fixed outcome model
+#' Create simulation profile from PLP data and an outcome model
 #'
 #' @param plpData An object of type \code{plpData} as generated using the \cr\code{getPlpData} function.'
+#' @param outcomeModels Optional named numeric vector or list of named numeric vectors with outcome model coefficients.
 #' @return An object of type \code{plpDataSimulationProfile}.
 #' @keywords internal
 #' @noRd
-createSimulationProfile <- function(plpData) {
+createSimulationProfile <- function(plpData, outcomeModels = NULL) {
   writeLines("Computing covariate prevalence") # (Note: currently assuming binary covariates)
   sums <- plpData$covariateData$covariates %>%
     dplyr::group_by(.data$covariateId) %>%
@@ -49,18 +50,16 @@ createSimulationProfile <- function(plpData) {
 
   outcomeRate <- nrow(plpData$outcomes) / nrow(plpData$cohorts)
   writeLines("Fitting outcome model(s)")
-  outcomeModels <- vector("list", length(plpData$metaData$databaseDetails$outcomeIds))
-  for (i in seq_along(plpData$metaData$databaseDetails$outcomeIds)) {
-   coefficients <- c("(Intercept)" = -2, 
-       "1002" = 0.04,  # age
-       "8532001" = 0.5,   # female 
-       "81893102" = 0.5, # ulcerative colitis
-       "4266809102" = 1.0, # Diverticular disease
-       "4310024102" = 1.5, #Angiodysplasia of stomach
-       "1112807402" = 0.7, # Aspirin
-       "1177480402" = 0.6, # Ibuprofen
-       "439777102" = 0.8)  # Anemia
-    outcomeModels[[i]] <- coefficients
+  outcomeIds <- plpData$metaData$databaseDetails$outcomeIds
+  if (is.null(outcomeModels)) {
+    outcomeModels <- vector("list", length(outcomeIds))
+    for (i in seq_along(outcomeIds)) {
+      outcomeModels[[i]] <- createDefaultSimulationOutcomeModel(
+        covariatePrevalence = covariatePrevalence
+      )
+    }
+  } else {
+    outcomeModels <- normalizeSimulationOutcomeModels(outcomeModels, length(outcomeIds))
   }
 
   timeMax <- max(plpData$outcomes$daysToEvent)
@@ -77,8 +76,100 @@ createSimulationProfile <- function(plpData) {
     covariateRef = plpData$covariateData$covariateRef %>% dplyr::collect()
   )
   class(result) <- "plpDataSimulationProfile"
+  validateSimulationOutcomeModels(result)
   return(result)
 }
+
+normalizeSimulationOutcomeModels <- function(outcomeModels, numberOfOutcomeIds) {
+  if (is.numeric(outcomeModels)) {
+    outcomeModels <- list(outcomeModels)
+  }
+
+  if (!is.list(outcomeModels)) {
+    stop("outcomeModels must be a named numeric vector or list of named numeric vectors")
+  }
+
+  if (length(outcomeModels) == 1 && numberOfOutcomeIds > 1) {
+    outcomeModels <- rep(outcomeModels, numberOfOutcomeIds)
+  }
+
+  if (length(outcomeModels) != numberOfOutcomeIds) {
+    stop("outcomeModels must contain one model for each outcomeId")
+  }
+
+  for (i in seq_along(outcomeModels)) {
+    if (!is.numeric(outcomeModels[[i]])) {
+      stop(sprintf("Outcome model %s must be a named numeric vector", i))
+    }
+    coefficientIds <- names(outcomeModels[[i]])
+    if (is.null(coefficientIds) || any(is.na(coefficientIds)) || any(coefficientIds == "")) {
+      stop(sprintf("Outcome model %s must have names for all coefficients", i))
+    }
+  }
+
+  return(outcomeModels)
+}
+
+createDefaultSimulationOutcomeModel <- function(covariatePrevalence) {
+  availableCovariateIds <- names(covariatePrevalence)
+
+  preferredCoefficients <- c(
+    "1002" = 0.04, # age
+    "8532001" = 0.5, # female
+    "81893102" = 0.5, # ulcerative colitis
+    "4266809102" = 1.0, # diverticular disease
+    "4310024102" = 1.5, # angiodysplasia of stomach
+    "1112807402" = 0.7, # aspirin
+    "1177480402" = 0.6, # ibuprofen
+    "439777102" = 0.8 # anemia
+  )
+  coefficients <- c(
+    "(Intercept)" = -2,
+    preferredCoefficients[names(preferredCoefficients) %in% availableCovariateIds]
+  )
+
+  missingIds <- setdiff(names(preferredCoefficients), availableCovariateIds)
+  if (length(missingIds) > 0) {
+    warning(
+      sprintf(
+        paste(
+          "Default outcome model omitted %s coefficient covariateId(s)",
+          "not available in covariateInfo$covariatePrevalence: %s"
+        ),
+        length(missingIds),
+        paste(head(missingIds, 10), collapse = ", ")
+      )
+    )
+  }
+  if (length(coefficients) == 1) {
+    warning("Default outcome model contains only an intercept; simulated outcomes may have no covariate signal")
+  }
+
+  return(coefficients)
+}
+
+validateSimulationOutcomeModels <- function(plpDataSimulationProfile) {
+  availableCovariateIds <- names(plpDataSimulationProfile$covariateInfo$covariatePrevalence)
+  for (i in seq_along(plpDataSimulationProfile$outcomeModels)) {
+    coefficientIds <- names(plpDataSimulationProfile$outcomeModels[[i]])
+    coefficientIds <- coefficientIds[!is.na(coefficientIds) & coefficientIds != "(Intercept)"]
+    missingIds <- setdiff(coefficientIds, availableCovariateIds)
+    if (length(missingIds) > 0) {
+      stop(
+        sprintf(
+          paste(
+            "Outcome model %s references %s covariateId(s) that are not available",
+            "in covariateInfo$covariatePrevalence: %s"
+          ),
+          i,
+          length(missingIds),
+          paste(head(missingIds, 10), collapse = ", ")
+        )
+      )
+    }
+  }
+}
+
 #' Generate simulated data
 #'
 #' @description
@@ -121,9 +212,10 @@ simulatePlpData <- function(plpDataSimulationProfile, n = 10000, seed = NULL) {
   }
 
   # Note: currently, simulation is done completely in-memory. Could easily do batch-wise
-  writeLines("Generating covariates")
   covariatePrevalence <- plpDataSimulationProfile$covariateInfo$covariatePrevalence
+  validateSimulationOutcomeModels(plpDataSimulationProfile)
 
+  writeLines("Generating covariates")
   personsPerCov <- stats::rpois(n = length(covariatePrevalence), lambda = covariatePrevalence * n)
   personsPerCov[personsPerCov > n] <- n
   rowId <- unlist(sapply(personsPerCov[personsPerCov > 0], function(x, n) sample.int(size = x, n), n = n))

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -18,11 +18,11 @@ test_that("create simulation profile works", {
   cohorts <- data.frame(rowId = 1:10, subjectId = 1:10, targetId = rep(1, 10))
   covariates <- data.frame(
     rowId = c(rep(1:10, each = 2), 1:10),
-    covariateId = c(rep(c(1002, 14310024102), 10), rep(8532, 10)),
+    covariateId = c(rep(c(1002, 14310024102), 10), rep(8532001, 10)),
     covariateValue = c(stats::runif(20), stats::rbinom(10, 1, 0.5))
   )
   covariateRef <- data.frame(
-    covariateId = c(1002, 14310024102, 8532),
+    covariateId = c(1002, 14310024102, 8532001),
     covariateName = c("cont1", "cont2", "bin1"),
     analysisId = c(1, 1, 2)
   )
@@ -48,7 +48,10 @@ test_that("create simulation profile works", {
       analysisRef = analysisRef
     )
   )
-  simProfile <- createSimulationProfile(simData)
+  expect_warning(
+    simProfile <- createSimulationProfile(simData),
+    "Default outcome model omitted"
+  )
   expect_type(simProfile, "list")
   expect_s3_class(simProfile, "plpDataSimulationProfile")
   expect_true(all(c(
@@ -59,7 +62,7 @@ test_that("create simulation profile works", {
   prevalence <- simProfile$covariateInfo$covariatePrevalence
   expect_type(prevalence, "double")
   expect_equal(as.numeric(prevalence["1002"]), 1)
-  expect_equal(as.numeric(prevalence["8532"]), 1)
+  expect_equal(as.numeric(prevalence["8532001"]), 1)
   expect_equal(as.numeric(prevalence["14310024102"]), 1)
 
   continuousCovs <- simProfile$covariateInfo$continuousCovariates
@@ -75,8 +78,23 @@ test_that("create simulation profile works", {
   expect_equal(simProfile$outcomeModels[[1]][["1002"]], 0.04)
   expect_equal(simProfile$outcomeModels[[1]][["8532001"]], 0.5)
   expect_false("8532" %in% names(simProfile$outcomeModels[[1]]))
+  expect_true(all(
+    setdiff(names(simProfile$outcomeModels[[1]]), "(Intercept)") %in% names(prevalence)
+  ))
   expect_equal(simProfile$metaData, metaData)
   expect_equal(simProfile$covariateRef, as.data.frame(covariateRef))
+
+  customOutcomeModel <- c("(Intercept)" = -1, "1002" = 0.1, "8532001" = 0.3)
+  customProfile <- createSimulationProfile(simData, outcomeModels = customOutcomeModel)
+  expect_equal(customProfile$outcomeModels[[1]], customOutcomeModel)
+
+  expect_error(
+    createSimulationProfile(
+      simData,
+      outcomeModels = c("(Intercept)" = -1, "9999" = 0.3)
+    ),
+    "9999"
+  )
 })
 
 test_that("simulatePlpData works", {
@@ -86,7 +104,7 @@ test_that("simulatePlpData works", {
   }
   dummyProfile <- list(
     covariateInfo = list(
-      covariatePrevalence = c("1002" = 1, "8532" = 0.3, "2001" = 0.5), continuousCovariates = data.frame(
+      covariatePrevalence = c("1002" = 1, "8532001" = 0.3, "2001" = 0.5), continuousCovariates = data.frame(
         covariateId = 1002,
         mean = 50,
         sd = 5,
@@ -98,7 +116,7 @@ test_that("simulatePlpData works", {
       covariateId = 2001,
       covariateName = "continuous feature",
       stringsAsFactors = FALSE
-    ), timeMax = c(100), outcomeModels = list(c("(Intercept)" = -2, "1002" = 0.04, "8532" = 0.05)),
+    ), timeMax = c(100), outcomeModels = list(c("(Intercept)" = -2, "1002" = 0.04, "8532001" = 0.05)),
     metaData = list(
       databaseDetails = list(
         outcomeIds = 3
@@ -136,4 +154,32 @@ test_that("simulatePlpData works", {
   expect_equal(simData$metaData$databaseDetails$cdmVersion, 5)
   expect_equal(simData$metaData$databaseDetails$targetId, 1) 
   expect_equal(simData$metaData$databaseDetails$outcomeIds, 3)
+})
+
+test_that("simulatePlpData rejects outcome models with unavailable covariates", {
+  invalidProfile <- list(
+    covariateInfo = list(
+      covariatePrevalence = c("1002" = 1),
+      continuousCovariates = data.frame(
+        covariateId = 1002,
+        mean = 50,
+        sd = 5,
+        min = 30,
+        max = 70
+      )
+    ),
+    covariateRef = data.frame(
+      covariateId = 1002,
+      covariateName = "age",
+      stringsAsFactors = FALSE
+    ),
+    timeMax = c(100),
+    outcomeModels = list(c("(Intercept)" = -2, "1002" = 0.04, "9999" = 0.5)),
+    metaData = list(databaseDetails = list(outcomeIds = 3))
+  )
+
+  expect_error(
+    simulatePlpData(invalidProfile, n = 100, seed = 42),
+    "9999"
+  )
 })


### PR DESCRIPTION
## Summary
- allow createSimulationProfile() to accept user-supplied outcome models
- keep the default simulation outcome model fixed, but omit unavailable covariates with a warning
- validate outcome model covariates in profiles before simulation so missing signal is not silently ignored

## Testing
- testthat::test_file("tests/testthat/test-simulation.R")
- git diff --check