### PR TITLE
Support PLP models in simulation profile outcomeModels

### DIFF
--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -19,8 +19,27 @@
 #' Create simulation profile from PLP data and an outcome model
 #'
 #' @param plpData An object of type \code{plpData} as generated using the \cr\code{getPlpData} function.'
-#' @param outcomeModels Optional named numeric vector or list of named numeric vectors with outcome model coefficients.
+#' @param outcomeModels Optional outcome model specification. This can be a named numeric vector,
+#'   a list of named numeric vectors, a Cyclops/GLM coefficient data frame, a trained model, a
+#'   \code{plpModel}, or a \code{runPlp} result. When a \code{plpModel} or \code{runPlp}
+#'   result is supplied, the model's saved preprocessing is applied before generating outcome risks.
 #' @return An object of type \code{plpDataSimulationProfile}.
+#' @examplesIf rlang::is_installed("Eunomia") && rlang::is_installed("curl") && curl::has_internet()
+#' \donttest{ \dontshow{ # takes too long }
+#' plpData <- getEunomiaPlpData()
+#' saveLoc <- file.path(tempdir(), "simulationProfile")
+#' plpResult <- runPlp(
+#'   plpData = plpData,
+#'   outcomeId = 3,
+#'   analysisId = 1,
+#'   saveDirectory = saveLoc
+#' )
+#' simulationProfile <- PatientLevelPrediction:::createSimulationProfile(
+#'   plpData = plpData,
+#'   outcomeModels = plpResult
+#' )
+#' simulatedData <- simulatePlpData(simulationProfile, n = 100, seed = 42)
+#' }
 #' @keywords internal
 #' @noRd
 createSimulationProfile <- function(plpData, outcomeModels = NULL) {
@@ -53,13 +72,16 @@ createSimulationProfile <- function(plpData, outcomeModels = NULL) {
   outcomeIds <- plpData$metaData$databaseDetails$outcomeIds
   if (is.null(outcomeModels)) {
     outcomeModels <- vector("list", length(outcomeIds))
+    outcomeModelPlpModels <- vector("list", length(outcomeIds))
     for (i in seq_along(outcomeIds)) {
       outcomeModels[[i]] <- createDefaultSimulationOutcomeModel(
         covariatePrevalence = covariatePrevalence
       )
     }
   } else {
-    outcomeModels <- normalizeSimulationOutcomeModels(outcomeModels, length(outcomeIds))
+    normalizedOutcomeModels <- normalizeSimulationOutcomeModels(outcomeModels, length(outcomeIds))
+    outcomeModels <- normalizedOutcomeModels$outcomeModels
+    outcomeModelPlpModels <- normalizedOutcomeModels$outcomeModelPlpModels
   }
 
   timeMax <- max(plpData$outcomes$daysToEvent)
@@ -72,6 +94,7 @@ createSimulationProfile <- function(plpData, outcomeModels = NULL) {
     timeMax = timeMax,
     outcomeRate = outcomeRate,
     outcomeModels = outcomeModels,
+    outcomeModelPlpModels = outcomeModelPlpModels,
     metaData = plpData$metaData,
     covariateRef = plpData$covariateData$covariateRef %>% dplyr::collect()
   )
@@ -81,16 +104,35 @@ createSimulationProfile <- function(plpData, outcomeModels = NULL) {
 }
 
 normalizeSimulationOutcomeModels <- function(outcomeModels, numberOfOutcomeIds) {
-  if (is.numeric(outcomeModels)) {
+  outcomeModel <- coerceSimulationOutcomeModel(outcomeModels)
+  if (!is.null(outcomeModel)) {
+    outcomeModels <- list(outcomeModel$outcomeModel)
+    outcomeModelPlpModels <- list(outcomeModel$plpModel)
+  } else if (is.data.frame(outcomeModels)) {
     outcomeModels <- list(outcomeModels)
+    outcomeModelPlpModels <- list(NULL)
+  } else if (is.list(outcomeModels)) {
+    coercedOutcomeModels <- lapply(outcomeModels, function(outcomeModel) {
+      coercedOutcomeModel <- coerceSimulationOutcomeModel(outcomeModel)
+      if (is.null(coercedOutcomeModel)) {
+        return(list(outcomeModel = outcomeModel, plpModel = NULL))
+      }
+      return(coercedOutcomeModel)
+    })
+    outcomeModels <- lapply(coercedOutcomeModels, function(outcomeModel) outcomeModel$outcomeModel)
+    outcomeModelPlpModels <- lapply(coercedOutcomeModels, function(outcomeModel) outcomeModel$plpModel)
   }
 
   if (!is.list(outcomeModels)) {
-    stop("outcomeModels must be a named numeric vector or list of named numeric vectors")
+    stop(paste(
+      "outcomeModels must be a named numeric vector, a list of named numeric vectors,",
+      "a supported model object, or a list of supported model objects"
+    ))
   }
 
   if (length(outcomeModels) == 1 && numberOfOutcomeIds > 1) {
     outcomeModels <- rep(outcomeModels, numberOfOutcomeIds)
+    outcomeModelPlpModels <- rep(outcomeModelPlpModels, numberOfOutcomeIds)
   }
 
   if (length(outcomeModels) != numberOfOutcomeIds) {
@@ -107,7 +149,88 @@ normalizeSimulationOutcomeModels <- function(outcomeModels, numberOfOutcomeIds) 
     }
   }
 
-  return(outcomeModels)
+  return(list(
+    outcomeModels = outcomeModels,
+    outcomeModelPlpModels = outcomeModelPlpModels
+  ))
+}
+
+coerceSimulationOutcomeModel <- function(outcomeModel) {
+  if (is.numeric(outcomeModel)) {
+    return(list(outcomeModel = outcomeModel, plpModel = NULL))
+  }
+
+  if (is.data.frame(outcomeModel)) {
+    coefficients <- coerceSimulationCoefficientDataFrame(outcomeModel)
+    if (is.null(coefficients)) {
+      return(NULL)
+    }
+    return(list(outcomeModel = coefficients, plpModel = NULL))
+  }
+
+  if (!is.list(outcomeModel)) {
+    return(NULL)
+  }
+
+  if (inherits(outcomeModel, "runPlp") && inherits(outcomeModel$model, "plpModel")) {
+    return(coerceSimulationPlpModel(outcomeModel$model))
+  }
+
+  if (inherits(outcomeModel, "plpModel")) {
+    return(coerceSimulationPlpModel(outcomeModel))
+  }
+
+  if (!is.null(outcomeModel$coefficients)) {
+    coefficients <- coerceSimulationCoefficientDataFrame(
+      outcomeModel$coefficients,
+      intercept = outcomeModel$intercept
+    )
+    if (is.null(coefficients)) {
+      return(NULL)
+    }
+    return(list(outcomeModel = coefficients, plpModel = NULL))
+  }
+
+  if (!is.null(outcomeModel$model)) {
+    return(coerceSimulationOutcomeModel(outcomeModel$model))
+  }
+
+  return(NULL)
+}
+
+coerceSimulationPlpModel <- function(plpModel) {
+  outcomeModel <- coerceSimulationOutcomeModel(plpModel$model)
+  if (is.null(outcomeModel)) {
+    return(NULL)
+  }
+  outcomeModel$plpModel <- plpModel
+  return(outcomeModel)
+}
+
+coerceSimulationCoefficientDataFrame <- function(coefficients, intercept = NULL) {
+  if (!is.data.frame(coefficients)) {
+    return(NULL)
+  }
+
+  if (all(c("betas", "covariateIds") %in% colnames(coefficients))) {
+    outcomeModel <- stats::setNames(
+      as.numeric(coefficients$betas),
+      as.character(coefficients$covariateIds)
+    )
+  } else if (all(c("coefficient", "covariateId") %in% colnames(coefficients))) {
+    outcomeModel <- stats::setNames(
+      as.numeric(coefficients$coefficient),
+      as.character(coefficients$covariateId)
+    )
+  } else {
+    return(NULL)
+  }
+
+  if (!is.null(intercept) && !"(Intercept)" %in% names(outcomeModel)) {
+    outcomeModel <- c("(Intercept)" = as.numeric(intercept)[[1]], outcomeModel)
+  }
+
+  return(outcomeModel)
 }
 
 createDefaultSimulationOutcomeModel <- function(covariatePrevalence) {
@@ -267,27 +390,39 @@ simulatePlpData <- function(plpDataSimulationProfile, n = 10000, seed = NULL) {
 
   writeLines("Generating outcomes")
   allOutcomes <- vector("list", length(plpDataSimulationProfile$metaData$databaseDetails$outcomeIds))
+  allSimulationTruth <- vector("list", length(plpDataSimulationProfile$metaData$databaseDetails$outcomeIds))
   outcomeIds <- plpDataSimulationProfile$metaData$databaseDetails$outcomeIds
   timeMax <- max(plpDataSimulationProfile$timeMax)
   for (i in seq_along(outcomeIds)) {
-    coefficients <- data.frame(
-      betas = as.numeric(plpDataSimulationProfile$outcomeModels[[i]]),
-      covariateIds = names(plpDataSimulationProfile$outcomeModels[[i]])
+    prediction <- predictSimulationOutcomeRisk(
+      outcomeModel = plpDataSimulationProfile$outcomeModels[[i]],
+      plpModel = plpDataSimulationProfile$outcomeModelPlpModels[[i]],
+      cohorts = cohorts,
+      covariateData = covariateData,
+      metaData = plpDataSimulationProfile$metaData
     )
-    prediction <- predictCyclopsType(coefficients,
-      cohorts,
-      covariateData,
-      modelType = "logistic"
+    outcomeCount <- stats::rbinom(nrow(prediction), size = 1, prob = prediction$value)
+    daysToEvent <- rep(NA_integer_, nrow(prediction))
+    eventRows <- outcomeCount != 0
+    daysToEvent[eventRows] <- round(stats::runif(sum(eventRows), 0, timeMax))
+    linearPredictor <- rep(NA_real_, nrow(prediction))
+    if ("rawValue" %in% colnames(prediction)) {
+      linearPredictor <- prediction$rawValue
+    }
+    simulationTruth <- data.frame(
+      rowId = prediction$rowId,
+      outcomeId = outcomeIds[i],
+      linearPredictor = linearPredictor,
+      trueRisk = prediction$value,
+      outcomeCount = outcomeCount,
+      daysToEvent = daysToEvent
     )
-    outcomes <- prediction
-    outcomes$outcomeCount <- stats::rbinom(nrow(outcomes), size = 1, prob = outcomes$value)
-    outcomes <- outcomes[outcomes$outcomeCount != 0, ]
-    outcomes$outcomeId <- outcomeIds[i]
-    outcomes$daysToEvent <- round(stats::runif(nrow(outcomes), 0, timeMax))
-    outcomes <- outcomes[, c("rowId", "outcomeId", "outcomeCount", "daysToEvent")]
+    outcomes <- simulationTruth[simulationTruth$outcomeCount != 0, c("rowId", "outcomeId", "outcomeCount", "daysToEvent")]
     allOutcomes[[i]] <- outcomes
+    allSimulationTruth[[i]] <- simulationTruth
   }
   allOutcomes <- dplyr::bind_rows(allOutcomes)
+  simulationTruth <- dplyr::bind_rows(allSimulationTruth)
 
   covariateData$coefficients <- NULL
 
@@ -332,6 +467,7 @@ simulatePlpData <- function(plpDataSimulationProfile, n = 10000, seed = NULL) {
   result <- list(
     cohorts = cohorts,
     outcomes = allOutcomes,
+    simulationTruth = simulationTruth,
     covariateData = covariateData,
     timeRef = NULL,
     metaData = metaData
@@ -339,4 +475,31 @@ simulatePlpData <- function(plpDataSimulationProfile, n = 10000, seed = NULL) {
 
   class(result) <- "plpData"
   return(result)
+}
+
+predictSimulationOutcomeRisk <- function(outcomeModel, plpModel, cohorts, covariateData, metaData) {
+  if (!is.null(plpModel)) {
+    plpData <- list(
+      cohorts = cohorts,
+      outcomes = data.frame(),
+      covariateData = covariateData,
+      metaData = metaData
+    )
+    class(plpData) <- "plpData"
+    return(predictPlp(
+      plpModel = plpModel,
+      plpData = plpData,
+      population = cohorts
+    ))
+  }
+
+  coefficients <- data.frame(
+    betas = as.numeric(outcomeModel),
+    covariateIds = names(outcomeModel)
+  )
+  return(predictCyclopsType(coefficients,
+    cohorts,
+    covariateData,
+    modelType = "logistic"
+  ))
 }

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -88,6 +88,92 @@ test_that("create simulation profile works", {
   customProfile <- createSimulationProfile(simData, outcomeModels = customOutcomeModel)
   expect_equal(customProfile$outcomeModels[[1]], customOutcomeModel)
 
+  cyclopsCoefficients <- data.frame(
+    betas = c(-1, 0.1, 0.3),
+    covariateIds = c("(Intercept)", "1002", "8532001"),
+    stringsAsFactors = FALSE
+  )
+  cyclopsModel <- list(coefficients = cyclopsCoefficients)
+  plpModel <- list(model = cyclopsModel)
+  class(plpModel) <- "plpModel"
+  plpResult <- list(model = plpModel)
+  class(plpResult) <- "runPlp"
+
+  cyclopsCoefficientProfile <- createSimulationProfile(simData, outcomeModels = cyclopsCoefficients)
+  expect_equal(cyclopsCoefficientProfile$outcomeModels[[1]], customOutcomeModel)
+
+  cyclopsProfile <- createSimulationProfile(simData, outcomeModels = cyclopsModel)
+  expect_equal(cyclopsProfile$outcomeModels[[1]], customOutcomeModel)
+
+  plpModelProfile <- createSimulationProfile(simData, outcomeModels = plpModel)
+  expect_equal(plpModelProfile$outcomeModels[[1]], customOutcomeModel)
+
+  plpResultProfile <- createSimulationProfile(simData, outcomeModels = plpResult)
+  expect_equal(plpResultProfile$outcomeModels[[1]], customOutcomeModel)
+
+  glmModel <- list(
+    intercept = -1,
+    coefficients = data.frame(
+      covariateId = c(1002, 8532001),
+      coefficient = c(0.1, 0.3)
+    )
+  )
+  glmProfile <- createSimulationProfile(simData, outcomeModels = glmModel)
+  expect_equal(glmProfile$outcomeModels[[1]], customOutcomeModel)
+
+  glmModelWithInterceptCoefficient <- list(
+    intercept = 0,
+    coefficients = data.frame(
+      covariateId = c("(Intercept)", "1002", "8532001"),
+      coefficient = c(-1, 0.1, 0.3)
+    )
+  )
+  glmWithInterceptProfile <- createSimulationProfile(
+    simData,
+    outcomeModels = glmModelWithInterceptCoefficient
+  )
+  expect_equal(glmWithInterceptProfile$outcomeModels[[1]], customOutcomeModel)
+
+  twoOutcomeSimData <- simData
+  twoOutcomeSimData$metaData$databaseDetails$outcomeIds <- c(1, 2)
+  repeatedOutcomeModelProfile <- createSimulationProfile(
+    twoOutcomeSimData,
+    outcomeModels = cyclopsModel
+  )
+  expect_equal(repeatedOutcomeModelProfile$outcomeModels, list(customOutcomeModel, customOutcomeModel))
+
+  secondOutcomeModel <- c("(Intercept)" = -2, "1002" = 0.2, "8532001" = 0.4)
+  twoOutcomeProfile <- createSimulationProfile(
+    twoOutcomeSimData,
+    outcomeModels = list(cyclopsModel, secondOutcomeModel)
+  )
+  expect_equal(twoOutcomeProfile$outcomeModels, list(customOutcomeModel, secondOutcomeModel))
+
+  expect_error(
+    createSimulationProfile(simData, outcomeModels = "not a model"),
+    "outcomeModels must be a named numeric vector"
+  )
+  expect_error(
+    createSimulationProfile(simData, outcomeModels = list(list(notCoefficients = TRUE))),
+    "Outcome model 1 must be a named numeric vector"
+  )
+  expect_error(
+    createSimulationProfile(simData, outcomeModels = list(coefficients = c(1, 2))),
+    "Outcome model 1 must have names for all coefficients"
+  )
+  expect_error(
+    createSimulationProfile(simData, outcomeModels = data.frame(x = 1, y = 2)),
+    "Outcome model 1 must be a named numeric vector"
+  )
+  expect_error(
+    createSimulationProfile(simData, outcomeModels = c(-1, 0.1)),
+    "Outcome model 1 must have names for all coefficients"
+  )
+  expect_error(
+    createSimulationProfile(twoOutcomeSimData, outcomeModels = list(customOutcomeModel, secondOutcomeModel, customOutcomeModel)),
+    "outcomeModels must contain one model for each outcomeId"
+  )
+
   expect_error(
     createSimulationProfile(
       simData,
@@ -147,6 +233,16 @@ test_that("simulatePlpData works", {
       expect_true(col %in% names(simData$outcomes))
     }
   }
+  expect_true(is.data.frame(simData$simulationTruth))
+  expect_equal(nrow(simData$simulationTruth), n)
+  expect_equal(
+    names(simData$simulationTruth),
+    c("rowId", "outcomeId", "linearPredictor", "trueRisk", "outcomeCount", "daysToEvent")
+  )
+  expect_equal(simData$simulationTruth$outcomeId, rep(3, n))
+  expect_true(all(simData$simulationTruth$trueRisk >= 0 & simData$simulationTruth$trueRisk <= 1))
+  expect_equal(nrow(simData$outcomes), sum(simData$simulationTruth$outcomeCount))
+  expect_true(all(is.na(simData$simulationTruth$daysToEvent[simData$simulationTruth$outcomeCount == 0])))
   expect_true(is.list(simData$metaData))
   expect_true("databaseDetails" %in% names(simData$metaData))
   expect_equal(simData$metaData$databaseDetails$cdmDatabaseSchema, "CDM_SCHEMA")
@@ -182,4 +278,58 @@ test_that("simulatePlpData rejects outcome models with unavailable covariates", 
     simulatePlpData(invalidProfile, n = 100, seed = 42),
     "9999"
   )
+})
+
+test_that("simulation outcome scoring applies PLP model preprocessing", {
+  covariateData <- Andromeda::andromeda(
+    covariates = data.frame(
+      rowId = 1,
+      covariateId = 1002,
+      covariateValue = 50
+    ),
+    covariateRef = data.frame(
+      covariateId = 1002,
+      covariateName = "age",
+      analysisId = 1
+    ),
+    analysisRef = data.frame(analysisId = 1)
+  )
+  class(covariateData) <- "CovariateData"
+  attr(class(covariateData), "package") <- "FeatureExtraction"
+
+  plpModel <- list(
+    model = list(
+      modelType = "logistic",
+      coefficients = data.frame(
+        betas = c(0, 1),
+        covariateIds = c("(Intercept)", "1002")
+      )
+    ),
+    preprocessing = list(
+      tidyCovariates = list(
+        normFactors = data.frame(covariateId = 1002, maxValue = 100),
+        deletedRedundantCovariateIds = numeric(0),
+        deletedInfrequentCovariateIds = numeric(0)
+      ),
+      featureEngineering = NULL
+    ),
+    modelDesign = list(
+      modelSettings = list(
+        settings = list(predict = "predictCyclops")
+      )
+    )
+  )
+  class(plpModel) <- "plpModel"
+  attr(plpModel, "modelType") <- "binary"
+
+  prediction <- predictSimulationOutcomeRisk(
+    outcomeModel = c("(Intercept)" = 0, "1002" = 1),
+    plpModel = plpModel,
+    cohorts = data.frame(rowId = 1),
+    covariateData = covariateData,
+    metaData = list()
+  )
+
+  expect_equal(prediction$rawValue, 0.5)
+  expect_equal(prediction$value, stats::plogis(0.5))
 })


### PR DESCRIPTION
## Summary
- Allow createSimulationProfile() outcomeModels to accept runPlp results, plpModel objects, trained model objects, and Cyclops/GLM coefficient data frames
- Keep the internal simulation outcome model format as named numeric vectors
- Add a Eunomia usage example and focused tests for supported input shapes

## Test
- Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-simulation.R")'