### PR TITLE
Run Codecov on macOS

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -111,13 +111,14 @@ jobs:
           path: check/*.tar.gz
           
       - name: Install covr
-        if: runner.os == 'Linux'
+        if: runner.os == 'macOS'
         run: |
+          install.packages("remotes")
           remotes::install_cran("covr")
         shell: Rscript {0}
         
       - name: Test coverage
-        if: runner.os == 'Linux'
+        if: runner.os == 'macOS'
         run: covr::codecov(token = "${{ secrets.CODECOV_TOKEN }}")
         shell: Rscript {0}
 


### PR DESCRIPTION
## Summary
- Move the covr install and Codecov upload steps from the Linux matrix job to the macOS matrix job
- Keep coverage running on a single R-CMD-check matrix entry

## Test
- Workflow-only change; not run locally