### PR TITLE
Fix IHT cross-validation predictions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ PatientLevelPrediction 6.6.0
 - Persisted hyperparameter settings and model names in the results data model to improve downstream model identification and viewing (#633, #632).
 
 ## Bug fixes
+- Fixed cross-validation prediction generation for iterative hard thresholding models by reusing fitted per-covariate prior variances.
 - Fixed simulation profile outcome models so generated coefficients only reference covariates available in the profile, added support for user-supplied outcome models, and invalid custom profiles now fail early instead of silently dropping outcome signal.
 - Improved upload of hyperparameter metadata and robustness of model settings persistence for database viewers and downstream tools (#628, #623).
 - Ensured existing GLM and scikit-learn model settings retain model identity so uploads generate distinct model design records (#614).

--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -143,7 +143,7 @@ fitCyclopsModel <- function(
     cyclopsData = cyclopsData,
     labels = trainData$covariateData$labels,
     folds = trainData$folds,
-    priorType = param$priorParams$priorType,
+    modelSettings = modelSettings,
     covariateData  = trainData$covariateData
   )
 
@@ -378,7 +378,7 @@ predictCyclopsType <- function(coefficients, population, covariateData, modelTyp
 
 
 createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, labels, folds,
-                               priorType, covariateData = NULL) {
+                               modelSettings, covariateData = NULL) {
   if (is.character(fit)) {
     coefficients <- c(0)
     names(coefficients) <- ""
@@ -431,11 +431,16 @@ createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, 
 
   # get CV - added && status == "OK" to only run if the model fit sucsessfully
   if (modelType == "logistic" && useCrossValidation && status == "OK") {
+    cvPrior <- createCyclopsCvPrior(
+      modelSettings = modelSettings,
+      fit = fit,
+      cyclopsData = cyclopsData
+    )
     outcomeModel$cv <- getCV(
       cyclopsData, 
       labels,
-      cvVariance = fit$variance, folds = folds,
-      priorType = priorType,
+      cvPrior = cvPrior,
+      folds = folds,
       covariateData = covariateData,
       modelType = modelType
     )
@@ -465,23 +470,98 @@ modelTypeToCyclopsModelType <- function(modelType, stratified = FALSE) {
   }
 }
 
+createCyclopsCvPrior <- function(modelSettings, fit, cyclopsData) {
+  priorFunction <- modelSettings$settings$priorfunction
+  priorParams <- modelSettings$param$priorParams
+
+  if (identical(priorFunction, "Cyclops::createPrior")) {
+    priorParams$variance <- fit$variance
+    priorParams$useCrossValidation <- FALSE
+    return(do.call(eval(parse(text = priorFunction)), priorParams))
+  }
+
+  cvVariance <- getFittedPriorVariance(fit)
+  if (!is.null(cvVariance)) {
+    if (length(cvVariance) != Cyclops::getNumberOfCovariates(cyclopsData)) {
+      stop(
+        "Fitted prior variance length does not match the number of Cyclops covariates"
+      )
+    }
+    priorType <- createNormalPriorType(
+      cyclopsData = cyclopsData,
+      exclude = priorParams$exclude,
+      forceIntercept = isTRUE(priorParams$forceIntercept)
+    )
+    return(Cyclops::createPrior(
+      priorType = priorType$types,
+      variance = cvVariance,
+      forceIntercept = isTRUE(priorParams$forceIntercept)
+    ))
+  }
+
+  stop(
+    "Cyclops fit did not return fitted final prior variances for CV refitting"
+  )
+}
+
+getFittedPriorVariance <- function(fit) {
+  fittedVarianceNames <- names(fit)[
+    grepl("FinalPriorVariance$", names(fit)) |
+      grepl("FinalPriorVariances$", names(fit))
+  ]
+  if (length(fittedVarianceNames) == 0) {
+    return(NULL)
+  }
+  fit[[fittedVarianceNames[1]]]
+}
+
+createNormalPriorType <- function(cyclopsData, exclude = c(), forceIntercept = FALSE) {
+  exclude <- checkCyclopsCovariates(cyclopsData, exclude)
+  covariateIds <- Cyclops::getCovariateIds(cyclopsData)
+  if (0 %in% covariateIds && !forceIntercept) {
+    interceptId <- 0
+    if (inherits(exclude, "integer64")) {
+      interceptId <- covariateIds[covariateIds == 0][1]
+    }
+    if (is.null(exclude)) {
+      exclude <- interceptId
+    } else if (!interceptId %in% exclude) {
+      exclude <- c(interceptId, exclude)
+    }
+  }
+
+  types <- rep("normal", Cyclops::getNumberOfCovariates(cyclopsData))
+  if (!is.null(exclude)) {
+    types[covariateIds %in% exclude] <- "none"
+  }
+  list(types = types, excludeCovariateIds = exclude)
+}
+
+checkCyclopsCovariates <- function(cyclopsData, covariates) {
+  if (is.null(covariates) || length(covariates) == 0) {
+    return(NULL)
+  }
+  saved <- covariates
+  if (inherits(covariates, "character")) {
+    indices <- match(covariates, cyclopsData$coefficientNames)
+    covariates <- Cyclops::getCovariateIds(cyclopsData)[indices]
+  }
+  if (any(is.na(covariates))) {
+    stop("Unable to match all covariates: ", paste(saved, collapse = ", "))
+  }
+  covariates
+}
+
 
 
 getCV <- function(
     cyclopsData,
     labels,
-    cvVariance,
+    cvPrior,
     folds,
-    priorType,
     covariateData = NULL,
     modelType = "logistic"
 ) {
-  fixed_prior <- Cyclops::createPrior(
-    priorType = priorType,
-    variance = cvVariance,
-    useCrossValidation = FALSE
-  )
-
   # add the index to the labels
   labels <- merge(labels, folds, by = "rowId")
 
@@ -490,7 +570,7 @@ getCV <- function(
     weights <- rep(1.0, Cyclops::getNumberOfRows(cyclopsData))
     weights[hold_out] <- 0.0
     subset_fit <- suppressWarnings(Cyclops::fitCyclopsModel(cyclopsData,
-      prior = fixed_prior,
+      prior = cvPrior,
       weights = weights
     ))
     coefficients <- stats::coef(subset_fit)

--- a/tests/testthat/test-cyclopsModels.R
+++ b/tests/testthat/test-cyclopsModels.R
@@ -301,6 +301,147 @@ test_that("test IHT incorrect inputs", {
 
 # ================ FUNCTION TESTING
 
+test_that("Cyclops CV prior uses fitted standard variance", {
+  cyclopsData <- Cyclops::convertToCyclopsData(
+    outcomes = data.frame(rowId = 1:4, y = c(0, 1, 0, 1)),
+    covariates = data.frame(
+      rowId = c(1, 2, 3, 4),
+      covariateId = c(100, 100, 200, 200),
+      covariateValue = c(1, 1, 1, 1)
+    ),
+    addIntercept = TRUE,
+    modelType = "lr",
+    checkRowIds = FALSE,
+    quiet = TRUE
+  )
+
+  cvPrior <- createCyclopsCvPrior(
+    modelSettings = setRidgeRegression(variance = 0.01),
+    fit = list(variance = 0.25),
+    cyclopsData = cyclopsData
+  )
+
+  expect_s3_class(cvPrior, "cyclopsPrior")
+  expect_equal(cvPrior$priorType, "normal")
+  expect_equal(cvPrior$variance, 0.25)
+  expect_false(cvPrior$useCrossValidation)
+})
+
+test_that("Cyclops CV prior supports fitted final variances", {
+  skip_if_not_installed("IterativeHardThresholding")
+  skip_on_cran()
+
+  cyclopsData <- Cyclops::convertToCyclopsData(
+    outcomes = data.frame(rowId = 1:4, y = c(0, 1, 0, 1)),
+    covariates = data.frame(
+      rowId = c(1, 2, 3, 4),
+      covariateId = c(100, 100, 200, 200),
+      covariateValue = c(1, 1, 1, 1)
+    ),
+    addIntercept = FALSE,
+    modelType = "lr",
+    checkRowIds = FALSE,
+    quiet = TRUE
+  )
+  finalVariance <- c(0.2, 0.3)
+  modelSettings <- setIterativeHardThresholding()
+
+  cvPrior <- createCyclopsCvPrior(
+    modelSettings = modelSettings,
+    fit = list(ihtFinalPriorVariance = finalVariance),
+    cyclopsData = cyclopsData
+  )
+
+  expect_s3_class(cvPrior, "cyclopsPrior")
+  expect_equal(length(cvPrior$priorType), length(finalVariance))
+  expect_equal(cvPrior$variance, finalVariance)
+})
+
+test_that("Cyclops CV prior maps per-covariate prior exclusions", {
+  cyclopsData <- Cyclops::convertToCyclopsData(
+    outcomes = data.frame(rowId = 1:4, y = c(0, 1, 0, 1)),
+    covariates = data.frame(
+      rowId = c(1, 2, 3, 4),
+      covariateId = c(100, 100, 200, 200),
+      covariateValue = c(1, 1, 1, 1)
+    ),
+    addIntercept = TRUE,
+    modelType = "lr",
+    checkRowIds = FALSE,
+    quiet = TRUE
+  )
+
+  priorType <- createNormalPriorType(cyclopsData, exclude = 100)
+  expect_equal(priorType$types, c("none", "none", "normal"))
+  expect_equal(as.numeric(priorType$excludeCovariateIds), c(0, 100))
+
+  priorType <- createNormalPriorType(cyclopsData, exclude = c("(Intercept)", "200"))
+  expect_equal(priorType$types, c("none", "normal", "none"))
+  expect_equal(as.numeric(priorType$excludeCovariateIds), c(0, 200))
+
+  priorType <- createNormalPriorType(cyclopsData, exclude = c(), forceIntercept = TRUE)
+  expect_equal(priorType$types, c("normal", "normal", "normal"))
+  expect_null(priorType$excludeCovariateIds)
+})
+
+test_that("Cyclops CV prior fails clearly for invalid per-covariate prior inputs", {
+  skip_if_not_installed("IterativeHardThresholding")
+  skip_on_cran()
+
+  cyclopsData <- Cyclops::convertToCyclopsData(
+    outcomes = data.frame(rowId = 1:4, y = c(0, 1, 0, 1)),
+    covariates = data.frame(
+      rowId = c(1, 2, 3, 4),
+      covariateId = c(100, 100, 200, 200),
+      covariateValue = c(1, 1, 1, 1)
+    ),
+    addIntercept = FALSE,
+    modelType = "lr",
+    checkRowIds = FALSE,
+    quiet = TRUE
+  )
+
+  expect_error(
+    createNormalPriorType(cyclopsData, exclude = "unknown"),
+    "Unable to match all covariates: unknown"
+  )
+  expect_error(
+    createCyclopsCvPrior(
+      modelSettings = setIterativeHardThresholding(),
+      fit = list(ihtFinalPriorVariance = c(0.2)),
+      cyclopsData = cyclopsData
+    ),
+    "Fitted prior variance length does not match the number of Cyclops covariates"
+  )
+  expect_error(
+    createCyclopsCvPrior(
+      modelSettings = setIterativeHardThresholding(),
+      fit = list(),
+      cyclopsData = cyclopsData
+    ),
+    "Cyclops fit did not return fitted final prior variances for CV refitting"
+  )
+})
+
+test_that("test IHT returns CV predictions", {
+  skip_if_offline()
+  skip_if_not_installed("IterativeHardThresholding")
+  skip_on_cran()
+
+  fitModel <- fitPlp(
+    trainData = trainData,
+    modelSettings = setIterativeHardThresholding(K = 5, seed = 42, maxIterations = 100),
+    analysisId = "ihtTest",
+    analysisPath = tempdir()
+  )
+
+  expect_equal(length(unique(fitModel$prediction$evaluationType)), 2)
+  expect_true("CV" %in% fitModel$prediction$evaluationType)
+  expect_equal(nrow(fitModel$prediction), nrow(trainData$labels) * 2)
+  expect_true(is.data.frame(fitModel$trainDetails$hyperParamSearch))
+  expect_true("CV" %in% fitModel$trainDetails$hyperParamSearch$fold)
+})
+
 test_that("test logistic regression runs", {
   skip_if_offline()
   modelSettings <- setLassoLogisticRegression()


### PR DESCRIPTION
## Summary
- Build Cyclops CV priors from fitted per-covariate final prior variances for IHT-style models
- Preserve standard Cyclops prior behavior for ridge/lasso models
- Add regression and helper tests for fitted prior variances, exclusion mapping, and clear error paths

## Tests
- testthat::test_file("tests/testthat/test-cyclopsModels.R")
- git diff --check