### PR TITLE
Fix IHT logistic intercept fitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ PatientLevelPrediction 6.6.0
 
 ## Bug fixes
 - Fixed cross-validation prediction generation for iterative hard thresholding models by reusing fitted per-covariate prior variances.
+- Restored intercept fitting for iterative hard thresholding logistic models.
 - Fixed simulation profile outcome models so generated coefficients only reference covariates available in the profile, added support for user-supplied outcome models, and invalid custom profiles now fail early instead of silently dropping outcome signal.
 - Improved upload of hyperparameter metadata and robustness of model settings persistence for database viewers and downstream tools (#628, #623).
 - Ensured existing GLM and scikit-learn model settings retain model identity so uploads generate distinct model design records (#614).

--- a/R/CyclopsSettings.R
+++ b/R/CyclopsSettings.R
@@ -355,7 +355,7 @@ setIterativeHardThresholding <- function(
     priorfunction = "IterativeHardThresholding::createIhtPrior",
     selectorType = "byRow",
     crossValidationInPrior = FALSE,
-    addIntercept = FALSE,
+    addIntercept = TRUE,
     useControl = FALSE,
     seed = seed[1],
     predict = "predictCyclops",

--- a/tests/testthat/test-cyclopsModels.R
+++ b/tests/testthat/test-cyclopsModels.R
@@ -244,7 +244,7 @@ test_that("set IHT inputs", {
   expect_equal(modelSet$settings$cyclopsModelType, "logistic")
   expect_equal(modelSet$settings$modelType, "binary")
   expect_equal(modelSet$settings$priorfunction, "IterativeHardThresholding::createIhtPrior")
-  expect_equal(modelSet$settings$addIntercept, FALSE)
+  expect_equal(modelSet$settings$addIntercept, TRUE)
   expect_equal(modelSet$settings$useControl, FALSE)
   expect_equal(modelSet$settings$crossValidationInPrior, FALSE)
 
@@ -428,16 +428,19 @@ test_that("test IHT returns CV predictions", {
   skip_if_not_installed("IterativeHardThresholding")
   skip_on_cran()
 
-  fitModel <- fitPlp(
-    trainData = trainData,
-    modelSettings = setIterativeHardThresholding(K = 5, seed = 42, maxIterations = 100),
-    analysisId = "ihtTest",
-    analysisPath = tempdir()
+  fitModel <- suppressWarnings(
+    fitPlp(
+      trainData = trainData,
+      modelSettings = setIterativeHardThresholding(K = 5, seed = 42, maxIterations = 100),
+      analysisId = "ihtTest",
+      analysisPath = tempdir()
+    )
   )
 
   expect_equal(length(unique(fitModel$prediction$evaluationType)), 2)
   expect_true("CV" %in% fitModel$prediction$evaluationType)
   expect_equal(nrow(fitModel$prediction), nrow(trainData$labels) * 2)
+  expect_true("(Intercept)" %in% fitModel$model$coefficients$covariateIds)
   expect_true(is.data.frame(fitModel$trainDetails$hyperParamSearch))
   expect_true("CV" %in% fitModel$trainDetails$hyperParamSearch$fold)
 })


### PR DESCRIPTION
## Summary
- restore intercept fitting for iterative hard thresholding logistic models
- update IHT settings coverage to expect the intercept-enabled default
- assert fitted IHT models include an intercept while retaining CV prediction coverage

## Testing
- Rscript -e "pkgload::load_all(); testthat::test_file('tests/testthat/test-cyclopsModels.R')"
- R CMD INSTALL --no-multiarch --with-keep.source .