### PR TITLE
fix: restore SVC probability state from JSON

### DIFF
--- a/R/SklearnToJson.R
+++ b/R/SklearnToJson.R
@@ -438,6 +438,21 @@ serializeSVM <- function(model) {
     "_gamma" = model$`_gamma`,
     "params" = model$get_params()
   )
+  if (reticulate::py_has_attr(model, "n_features_in_")) {
+    serialized_model["n_features_in_"] <- model$n_features_in_
+  }
+  if (reticulate::py_has_attr(model, "_effective_probability")) {
+    serialized_model["_effective_probability"] <- model$`_effective_probability`
+  }
+  if (reticulate::py_has_attr(model, "fit_status_")) {
+    serialized_model["fit_status_"] <- model$fit_status_
+  }
+  if (reticulate::py_has_attr(model, "_num_iter")) {
+    serialized_model["_num_iter"] <- model$`_num_iter`$tolist()
+  }
+  if (reticulate::py_has_attr(model, "n_iter_")) {
+    serialized_model["n_iter_"] <- model$n_iter_$tolist()
+  }
   if (inherits(model$support_vectors_, "numpy.ndarray")) {
     serialized_model["support_vectors_"] <- model$support_vectors_$tolist()
   } else {
@@ -458,6 +473,10 @@ serializeSVM <- function(model) {
   return(serialized_model)
 }
 
+pythonDictHasKey <- function(dict, key) {
+  reticulate::py_bool(dict$`__contains__`(key))
+}
+
 deSerializeSVM <- function(model_dict) {
   sklearn <- reticulate::import("sklearn", convert = FALSE)
   np <- reticulate::import("numpy", convert = FALSE)
@@ -475,6 +494,26 @@ deSerializeSVM <- function(model_dict) {
   model$`_probA` <- np$array(model_dict["probA_"])$astype(np$float64)
   model$`_probB` <- np$array(model_dict["probB_"])$astype(np$float64)
   model$`_intercept_` <- np$array(model_dict["_intercept_"])$astype(np$float64)
+  if (pythonDictHasKey(model_dict, "n_features_in_")) {
+    model$n_features_in_ <- model_dict["n_features_in_"]
+  } else {
+    model$n_features_in_ <- as.integer(reticulate::py_to_r(model_dict["shape_fit_"])[[2]])
+  }
+  if (pythonDictHasKey(model_dict, "_effective_probability")) {
+    model$`_effective_probability` <- model_dict["_effective_probability"]
+  } else {
+    probability <- reticulate::py_to_r(model$probability)
+    model$`_effective_probability` <- isTRUE(probability)
+  }
+  if (pythonDictHasKey(model_dict, "fit_status_")) {
+    model$fit_status_ <- model_dict["fit_status_"]
+  }
+  if (pythonDictHasKey(model_dict, "_num_iter")) {
+    model$`_num_iter` <- np$array(model_dict["_num_iter"])$astype(np$int32)
+  }
+  if (pythonDictHasKey(model_dict, "n_iter_")) {
+    model$n_iter_ <- np$array(model_dict["n_iter_"])$astype(np$int32)
+  }
 
   if (reticulate::py_bool((model_dict$support_vectors_["meta"] != reticulate::py_none())) &
     (reticulate::py_bool(model_dict$support_vectors_["meta"] == "csr"))) {

--- a/tests/testthat/test-sklearnJson.R
+++ b/tests/testthat/test-sklearnJson.R
@@ -161,7 +161,37 @@ test_that("SVM to json is correct", {
 
   loadedModel <- sklearnFromJson(path)
 
+  expect_true(reticulate::py_has_attr(loadedModel, "_effective_probability"))
+  expect_true(reticulate::py_has_attr(loadedModel, "n_features_in_"))
+
   loadedPredictions <- reticulate::py_to_r(loadedModel$predict_proba(xUnseen))
 
   expect_true(all.equal(predictions, loadedPredictions))
+
+  py <- reticulate::import_builtins(convert = FALSE)
+  json <- reticulate::import("json", convert = FALSE)
+  with(py$open(path, "r"), as = file, {
+    legacyModelDict <- json$load(fp = file)
+  })
+  for (key in c(
+    "n_features_in_",
+    "_effective_probability",
+    "fit_status_",
+    "_num_iter",
+    "n_iter_"
+  )) {
+    if (reticulate::py_bool(legacyModelDict$`__contains__`(key))) {
+      invisible(legacyModelDict$pop(key))
+    }
+  }
+  legacyPath <- file.path(tempdir(), "legacy-model.json")
+  with(py$open(legacyPath, "w"), as = file, {
+    json$dump(legacyModelDict, fp = file)
+  })
+
+  legacyLoadedModel <- sklearnFromJson(legacyPath)
+  legacyPredictions <- reticulate::py_to_r(legacyLoadedModel$predict_proba(xUnseen))
+
+  expect_true(reticulate::py_has_attr(legacyLoadedModel, "_effective_probability"))
+  expect_true(all.equal(predictions, legacyPredictions))
 })


### PR DESCRIPTION
## Summary
- persist and restore newer fitted SVC attributes used by sklearn 1.9 during predict_proba
- add fallback reconstruction for older SVM JSON files that lack those attributes
- extend SVM JSON test coverage for current and legacy JSON payloads

## Verification
- sparse SVC JSON roundtrip passed with scikit-learn 1.9.0
- sparse SVC JSON roundtrip passed with scikit-learn 1.7.2
- legacy-style JSON without the new keys still loads and matches predict_proba output
- git diff --check