### PR TITLE
Fix minimum dependency version support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\\.cache$
+^\.r-library$
 ^.vscode$
 standalone
 deploy.sh

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,7 +2,7 @@
 ^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^\\.cache$
+^\.cache$
 ^\.r-library$
 ^.vscode$
 standalone

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,5 +25,5 @@ _pkgdown.yml
 ^.venv$
 ^.notVenv$
 .cache
-^\\.git$
+^\.git$
 ^results$

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -31,6 +31,7 @@ env:
   R_LIBS_USER: ${{ github.workspace }}/.cache/r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+  RETICULATE_PYTHON: /usr/bin/python3
   RETICULATE_PY_VERSION: 3.11
   CDM5_POSTGRESQL_CDM_SCHEMA: ${{ secrets.CDM5_POSTGRESQL_CDM_SCHEMA }}
   CDM5_POSTGRESQL_OHDSI_SCHEMA: ${{ secrets.CDM5_POSTGRESQL_OHDSI_SCHEMA }}
@@ -85,6 +86,11 @@ jobs:
       - name: Prepare caches
         run: |
           mkdir -p "${R_LIBS_USER}" "${EUNOMIA_DATA_FOLDER}" "${UV_CACHE_DIR}"
+
+      - name: Install Python test dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "scikit-learn==1.3.2"
 
       - name: Restore R library cache
         id: cache-r-library-restore

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -1,0 +1,166 @@
+name: Dependency floor checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      r_version:
+        description: "R version to test. Use the latest patch release for the minimum supported R minor version."
+        required: true
+        default: "4.1.3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-floor-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  RSPM: https://packagemanager.posit.co/cran/__linux__/jammy/latest
+  R_LIBS_USER: ${{ github.workspace }}/.r-library
+  EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
+  UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+  RETICULATE_PY_VERSION: 3.11
+
+jobs:
+  dependency-floor:
+    runs-on: ubuntu-latest
+    container: rocker/r-ver:${{ inputs.r_version }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+
+      - name: Install system requirements
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            cmake \
+            curl \
+            git \
+            libbz2-dev \
+            libcurl4-openssl-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libfribidi-dev \
+            libgit2-dev \
+            libharfbuzz-dev \
+            libicu-dev \
+            libjpeg-dev \
+            liblzma-dev \
+            libomp-dev \
+            libpng-dev \
+            libssh-dev \
+            libssl-dev \
+            libtiff5-dev \
+            libxml2-dev \
+            make \
+            pandoc \
+            python3 \
+            python3-pip \
+            python3-venv \
+            zlib1g-dev
+
+      - name: Prepare caches
+        run: |
+          mkdir -p "${R_LIBS_USER}" "${EUNOMIA_DATA_FOLDER}" "${UV_CACHE_DIR}"
+
+      - name: Cache R library
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: dependency-floor-r${{ inputs.r_version }}-${{ hashFiles('DESCRIPTION', '.github/workflows/dependency-floor.yml') }}
+          restore-keys: |
+            dependency-floor-r${{ inputs.r_version }}-
+
+      - name: Cache Eunomia datasets
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.EUNOMIA_DATA_FOLDER }}
+          key: eunomia-v1-${{ runner.os }}-GiBleed_5.3
+
+      - name: Cache uv
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-v1-${{ runner.os }}-py${{ env.RETICULATE_PY_VERSION }}
+
+      - name: Install dependency floor
+        shell: Rscript {0}
+        run: |
+          repos <- Sys.getenv("RSPM", unset = "https://cloud.r-project.org")
+          install.packages(c("remotes", "rcmdcheck"), repos = repos)
+
+          description <- read.dcf("DESCRIPTION")[1, ]
+          dependencyFields <- intersect(
+            c("Depends", "Imports", "Suggests", "LinkingTo"),
+            names(description)
+          )
+          dependencyText <- paste(description[dependencyFields], collapse = ",")
+          dependencyText <- gsub("[\r\n]", " ", dependencyText)
+          dependencies <- trimws(unlist(strsplit(dependencyText, ",")))
+          dependencies <- dependencies[nzchar(dependencies)]
+
+          parsed <- regexec("^([A-Za-z0-9.]+)\\s*(?:\\(([^ ]+)\\s*([^)]+)\\))?$", dependencies)
+          parsed <- regmatches(dependencies, parsed)
+          parsed <- do.call(rbind, lapply(parsed, function(x) {
+            length(x) <- 4
+            data.frame(
+              package = x[2],
+              operator = x[3],
+              version = x[4],
+              stringsAsFactors = FALSE
+            )
+          }))
+          parsed <- parsed[parsed$package != "R", ]
+
+          floorDependencies <- parsed[parsed$operator == ">=", ]
+          write.csv(floorDependencies, "dependency-floor-requested.csv", row.names = FALSE)
+
+          for (i in seq_len(nrow(floorDependencies))) {
+            package <- floorDependencies$package[[i]]
+            version <- floorDependencies$version[[i]]
+            message("Installing floor dependency: ", package, " ", version)
+            remotes::install_version(
+              package = package,
+              version = version,
+              repos = repos,
+              dependencies = NA,
+              upgrade = "never"
+            )
+          }
+
+          remotes::install_deps(
+            dependencies = TRUE,
+            repos = repos,
+            upgrade = "never"
+          )
+
+          installed <- as.data.frame(installed.packages()[, c("Package", "Version")])
+          declared <- parsed$package
+          installed <- installed[installed$Package %in% declared, ]
+          installed <- installed[order(tolower(installed$Package)), ]
+          write.csv(installed, "dependency-floor-installed.csv", row.names = FALSE)
+
+      - name: Run R CMD check
+        shell: Rscript {0}
+        run: |
+          result <- rcmdcheck::rcmdcheck(
+            args = c("--no-manual", "--no-build-vignettes", "--ignore-vignettes"),
+            build_args = c("--no-manual", "--no-build-vignettes"),
+            error_on = "warning",
+            check_dir = "check"
+          )
+          print(result)
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: dependency-floor-results
+          path: |
+            check
+            dependency-floor-requested.csv
+            dependency-floor-installed.csv

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -32,6 +32,11 @@ env:
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
   RETICULATE_PY_VERSION: 3.11
+  CDM5_POSTGRESQL_CDM_SCHEMA: ${{ secrets.CDM5_POSTGRESQL_CDM_SCHEMA }}
+  CDM5_POSTGRESQL_OHDSI_SCHEMA: ${{ secrets.CDM5_POSTGRESQL_OHDSI_SCHEMA }}
+  CDM5_POSTGRESQL_PASSWORD: ${{ secrets.CDM5_POSTGRESQL_PASSWORD }}
+  CDM5_POSTGRESQL_SERVER: ${{ secrets.CDM5_POSTGRESQL_SERVER }}
+  CDM5_POSTGRESQL_USER: ${{ secrets.CDM5_POSTGRESQL_USER }}
 
 jobs:
   dependency-floor:

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -103,33 +103,42 @@ jobs:
         run: |
           repos <- Sys.getenv("RSPM", unset = "https://cloud.r-project.org")
           install.packages(c("remotes", "rcmdcheck"), repos = repos)
+          options(Ncpus = max(1L, parallel::detectCores()))
 
           installSuggests <- tolower(Sys.getenv("INSTALL_SUGGESTS", unset = "false")) == "true"
           description <- read.dcf("DESCRIPTION")[1, ]
-          dependencyFields <- c("Depends", "Imports", "LinkingTo")
-          if (installSuggests) {
-            dependencyFields <- c(dependencyFields, "Suggests")
-          }
+          hardDependencyFields <- intersect(c("Depends", "Imports", "LinkingTo"), names(description))
+          dependencyFields <- hardDependencyFields
+          suggestedPackages <- character()
           dependencyFields <- intersect(dependencyFields, names(description))
           message("Installing dependency fields: ", paste(dependencyFields, collapse = ", "))
 
-          dependencyText <- paste(description[dependencyFields], collapse = ",")
-          dependencyText <- gsub("[\r\n]", " ", dependencyText)
-          dependencies <- trimws(unlist(strsplit(dependencyText, ",")))
-          dependencies <- dependencies[nzchar(dependencies)]
+          parseDependencies <- function(fields) {
+            dependencyText <- paste(description[fields], collapse = ",")
+            dependencyText <- gsub("[\r\n]", " ", dependencyText)
+            dependencies <- trimws(unlist(strsplit(dependencyText, ",")))
+            dependencies <- dependencies[nzchar(dependencies)]
 
-          parsed <- regexec("^([A-Za-z0-9.]+)\\s*(?:\\(([^ ]+)\\s*([^)]+)\\))?$", dependencies)
-          parsed <- regmatches(dependencies, parsed)
-          parsed <- do.call(rbind, lapply(parsed, function(x) {
-            length(x) <- 4
-            data.frame(
-              package = x[2],
-              operator = x[3],
-              version = x[4],
-              stringsAsFactors = FALSE
-            )
-          }))
-          parsed <- parsed[parsed$package != "R", ]
+            parsed <- regexec("^([A-Za-z0-9.]+)\\s*(?:\\(([^ ]+)\\s*([^)]+)\\))?$", dependencies)
+            parsed <- regmatches(dependencies, parsed)
+            parsed <- do.call(rbind, lapply(parsed, function(x) {
+              length(x) <- 4
+              data.frame(
+                package = x[2],
+                operator = x[3],
+                version = x[4],
+                stringsAsFactors = FALSE
+              )
+            }))
+            parsed[parsed$package != "R", ]
+          }
+
+          parsed <- parseDependencies(dependencyFields)
+          if (installSuggests && "Suggests" %in% names(description)) {
+            suggested <- parseDependencies("Suggests")
+            suggestedPackages <- suggested$package
+            parsed <- rbind(parsed, suggested)
+          }
 
           floorDependencies <- parsed[parsed$operator == ">=", ]
           write.csv(floorDependencies, "dependency-floor-requested.csv", row.names = FALSE)
@@ -162,10 +171,23 @@ jobs:
           }
 
           remotes::install_deps(
-            dependencies = dependencyFields,
+            dependencies = hardDependencyFields,
             repos = repos,
             upgrade = "never"
           )
+
+          if (length(suggestedPackages) > 0) {
+            installedPackages <- rownames(installed.packages())
+            suggestedPackages <- setdiff(suggestedPackages, installedPackages)
+            if (length(suggestedPackages) > 0) {
+              message("Installing direct suggested packages: ", paste(suggestedPackages, collapse = ", "))
+              install.packages(
+                suggestedPackages,
+                repos = repos,
+                dependencies = hardDependencyFields
+              )
+            }
+          }
 
           for (i in seq_len(nrow(floorDependencies))) {
             package <- floorDependencies$package[[i]]

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -7,6 +7,11 @@ on:
         description: "R version to test. Use the latest patch release for the minimum supported R minor version."
         required: true
         default: "4.1.3"
+      install_suggests:
+        description: "Install Suggests too. This is slower and may require newer system/package floors."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -18,6 +23,7 @@ concurrency:
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.install_suggests }}
   RSPM: https://packagemanager.posit.co/cran/__linux__/focal/latest
   R_LIBS_USER: ${{ github.workspace }}/.r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
@@ -37,6 +43,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
+            build-essential \
             cmake \
             curl \
             git \
@@ -55,6 +62,7 @@ jobs:
             libssh-dev \
             libssl-dev \
             libtiff5-dev \
+            libwebp-dev \
             libxml2-dev \
             make \
             pandoc \
@@ -89,15 +97,21 @@ jobs:
 
       - name: Install dependency floor
         shell: Rscript {0}
+        env:
+          INSTALL_SUGGESTS: ${{ inputs.install_suggests }}
         run: |
           repos <- Sys.getenv("RSPM", unset = "https://cloud.r-project.org")
           install.packages(c("remotes", "rcmdcheck"), repos = repos)
 
+          installSuggests <- tolower(Sys.getenv("INSTALL_SUGGESTS", unset = "false")) == "true"
           description <- read.dcf("DESCRIPTION")[1, ]
-          dependencyFields <- intersect(
-            c("Depends", "Imports", "Suggests", "LinkingTo"),
-            names(description)
-          )
+          dependencyFields <- c("Depends", "Imports", "LinkingTo")
+          if (installSuggests) {
+            dependencyFields <- c(dependencyFields, "Suggests")
+          }
+          dependencyFields <- intersect(dependencyFields, names(description))
+          message("Installing dependency fields: ", paste(dependencyFields, collapse = ", "))
+
           dependencyText <- paste(description[dependencyFields], collapse = ",")
           dependencyText <- gsub("[\r\n]", " ", dependencyText)
           dependencies <- trimws(unlist(strsplit(dependencyText, ",")))
@@ -119,6 +133,12 @@ jobs:
           floorDependencies <- parsed[parsed$operator == ">=", ]
           write.csv(floorDependencies, "dependency-floor-requested.csv", row.names = FALSE)
 
+          remotes::install_deps(
+            dependencies = dependencyFields,
+            repos = repos,
+            upgrade = "never"
+          )
+
           for (i in seq_len(nrow(floorDependencies))) {
             package <- floorDependencies$package[[i]]
             version <- floorDependencies$version[[i]]
@@ -127,16 +147,10 @@ jobs:
               package = package,
               version = version,
               repos = repos,
-              dependencies = NA,
+              dependencies = FALSE,
               upgrade = "never"
             )
           }
-
-          remotes::install_deps(
-            dependencies = TRUE,
-            repos = repos,
-            upgrade = "never"
-          )
 
           installed <- as.data.frame(installed.packages()[, c("Package", "Version")])
           declared <- parsed$package

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -78,6 +78,7 @@ jobs:
             pandoc \
             pkg-config \
             python3 \
+            python3-dev \
             python3-pip \
             python3-venv \
             zlib1g-dev

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -24,9 +24,10 @@ env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
   _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.install_suggests }}
+  DEPENDENCY_FLOOR_CACHE_VERSION: v2
   RSPM: https://packagemanager.posit.co/cran/__linux__/focal/latest
-  R_LIBS: ${{ github.workspace }}/.r-library
-  R_LIBS_USER: ${{ github.workspace }}/.r-library
+  R_LIBS: ${{ github.workspace }}/../.r-library
+  R_LIBS_USER: ${{ github.workspace }}/../.r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
   RETICULATE_PY_VERSION: 3.11
@@ -84,9 +85,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: dependency-floor-r${{ inputs.r_version }}-${{ hashFiles('DESCRIPTION', '.github/workflows/dependency-floor.yml') }}
+          key: dependency-floor-${{ env.DEPENDENCY_FLOOR_CACHE_VERSION }}-focal-r${{ inputs.r_version }}-suggests-${{ inputs.install_suggests }}-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            dependency-floor-r${{ inputs.r_version }}-
+            dependency-floor-${{ env.DEPENDENCY_FLOOR_CACHE_VERSION }}-focal-r${{ inputs.r_version }}-suggests-${{ inputs.install_suggests }}-
 
       - name: Cache Eunomia datasets
         uses: actions/cache@v5

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -25,6 +25,7 @@ env:
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
   _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.install_suggests }}
   RSPM: https://packagemanager.posit.co/cran/__linux__/focal/latest
+  R_LIBS: ${{ github.workspace }}/.r-library
   R_LIBS_USER: ${{ github.workspace }}/.r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
@@ -78,8 +79,9 @@ jobs:
         run: |
           mkdir -p "${R_LIBS_USER}" "${EUNOMIA_DATA_FOLDER}" "${UV_CACHE_DIR}"
 
-      - name: Cache R library
-        uses: actions/cache@v5
+      - name: Restore R library cache
+        id: cache-r-library-restore
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.R_LIBS_USER }}
           key: dependency-floor-r${{ inputs.r_version }}-${{ hashFiles('DESCRIPTION', '.github/workflows/dependency-floor.yml') }}
@@ -103,6 +105,9 @@ jobs:
         env:
           INSTALL_SUGGESTS: ${{ inputs.install_suggests }}
         run: |
+          .libPaths(c(Sys.getenv("R_LIBS_USER"), .libPaths()))
+          message("R library paths: ", paste(.libPaths(), collapse = ", "))
+
           repos <- Sys.getenv("RSPM", unset = "https://cloud.r-project.org")
           install.packages(c("remotes", "rcmdcheck"), repos = repos)
           options(Ncpus = max(1L, parallel::detectCores()))
@@ -217,9 +222,19 @@ jobs:
           installed <- installed[order(tolower(installed$Package)), ]
           write.csv(installed, "dependency-floor-installed.csv", row.names = FALSE)
 
+      - name: Save R library cache
+        if: steps.cache-r-library-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ steps.cache-r-library-restore.outputs.cache-primary-key }}
+
       - name: Run R CMD check
         shell: Rscript {0}
         run: |
+          .libPaths(c(Sys.getenv("R_LIBS_USER"), .libPaths()))
+          message("R library paths: ", paste(.libPaths(), collapse = ", "))
+
           result <- rcmdcheck::rcmdcheck(
             args = c("--no-manual", "--no-build-vignettes", "--ignore-vignettes"),
             build_args = c("--no-manual", "--no-build-vignettes"),

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  NOT_CRAN: true
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
   _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.install_suggests }}
   DEPENDENCY_FLOOR_CACHE_VERSION: v3

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-  RSPM: https://packagemanager.posit.co/cran/__linux__/jammy/latest
+  RSPM: https://packagemanager.posit.co/cran/__linux__/focal/latest
   R_LIBS_USER: ${{ github.workspace }}/.r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -145,8 +145,8 @@ jobs:
 
           if (installSuggests) {
             compatibilityPins <- data.frame(
-              package = c("Matrix", "arrow", "xgboost"),
-              version = c("1.6-5", "17.0.0", "1.7.8.1"),
+              package = c("Matrix", "arrow", "pbkrtest", "xgboost"),
+              version = c("1.6-5", "17.0.0", "0.5.2", "1.7.8.1"),
               stringsAsFactors = FALSE
             )
             write.csv(compatibilityPins, "dependency-floor-compatibility-pins.csv", row.names = FALSE)
@@ -185,6 +185,13 @@ jobs:
                 suggestedPackages,
                 repos = repos,
                 dependencies = hardDependencyFields
+              )
+            }
+            missingSuggestedPackages <- setdiff(suggestedPackages, rownames(installed.packages()))
+            if (length(missingSuggestedPackages) > 0) {
+              stop(
+                "Failed to install direct suggested packages: ",
+                paste(missingSuggestedPackages, collapse = ", ")
               )
             }
           }

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -8,10 +8,10 @@ on:
         required: true
         default: "4.1.3"
       install_suggests:
-        description: "Install Suggests too. This is slower and may require newer system/package floors."
+        description: "Install Suggests too. Disable only for a faster import-only smoke check."
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -66,6 +66,7 @@ jobs:
             libxml2-dev \
             make \
             pandoc \
+            pkg-config \
             python3 \
             python3-pip \
             python3-venv \
@@ -133,6 +134,33 @@ jobs:
           floorDependencies <- parsed[parsed$operator == ">=", ]
           write.csv(floorDependencies, "dependency-floor-requested.csv", row.names = FALSE)
 
+          if (installSuggests) {
+            compatibilityPins <- data.frame(
+              package = c("Matrix", "arrow", "xgboost"),
+              version = c("1.6-5", "17.0.0", "1.7.8.1"),
+              stringsAsFactors = FALSE
+            )
+            write.csv(compatibilityPins, "dependency-floor-compatibility-pins.csv", row.names = FALSE)
+
+            for (i in seq_len(nrow(compatibilityPins))) {
+              package <- compatibilityPins$package[[i]]
+              version <- compatibilityPins$version[[i]]
+              message("Installing old-R compatibility pin: ", package, " ", version)
+              remotes::install_version(
+                package = package,
+                version = version,
+                repos = repos,
+                dependencies = FALSE,
+                upgrade = "never"
+              )
+            }
+          } else {
+            write.csv(data.frame(package = character(), version = character()),
+              "dependency-floor-compatibility-pins.csv",
+              row.names = FALSE
+            )
+          }
+
           remotes::install_deps(
             dependencies = dependencyFields,
             repos = repos,
@@ -177,4 +205,5 @@ jobs:
           path: |
             check
             dependency-floor-requested.csv
+            dependency-floor-compatibility-pins.csv
             dependency-floor-installed.csv

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -46,6 +46,7 @@ jobs:
             build-essential \
             cmake \
             curl \
+            default-jdk \
             git \
             libbz2-dev \
             libcurl4-openssl-dev \
@@ -71,6 +72,7 @@ jobs:
             python3-pip \
             python3-venv \
             zlib1g-dev
+          R CMD javareconf
 
       - name: Prepare caches
         run: |

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -204,16 +204,26 @@ jobs:
             }
           }
 
+          sourceFloorPackages <- c("Andromeda", "FeatureExtraction")
+          sourceRepos <- "https://cloud.r-project.org"
           for (i in seq_len(nrow(floorDependencies))) {
             package <- floorDependencies$package[[i]]
             version <- floorDependencies$version[[i]]
-            message("Installing floor dependency: ", package, " ", version)
+            useSource <- package %in% sourceFloorPackages
+            message(
+              "Installing floor dependency: ",
+              package,
+              " ",
+              version,
+              if (useSource) " from source" else ""
+            )
             remotes::install_version(
               package = package,
               version = version,
-              repos = repos,
+              repos = if (useSource) sourceRepos else repos,
               dependencies = FALSE,
-              upgrade = "never"
+              upgrade = "never",
+              type = if (useSource) "source" else getOption("pkgType")
             )
           }
 

--- a/.github/workflows/dependency-floor.yml
+++ b/.github/workflows/dependency-floor.yml
@@ -24,10 +24,10 @@ env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
   _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.install_suggests }}
-  DEPENDENCY_FLOOR_CACHE_VERSION: v2
+  DEPENDENCY_FLOOR_CACHE_VERSION: v3
   RSPM: https://packagemanager.posit.co/cran/__linux__/focal/latest
-  R_LIBS: ${{ github.workspace }}/../.r-library
-  R_LIBS_USER: ${{ github.workspace }}/../.r-library
+  R_LIBS: ${{ github.workspace }}/.cache/r-library
+  R_LIBS_USER: ${{ github.workspace }}/.cache/r-library
   EUNOMIA_DATA_FOLDER: ${{ github.workspace }}/.cache/eunomia
   UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
   RETICULATE_PY_VERSION: 3.11

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,21 +22,22 @@ URL: https://ohdsi.github.io/PatientLevelPrediction/, https://github.com/OHDSI/P
 BugReports: https://github.com/OHDSI/PatientLevelPrediction/issues
 VignetteBuilder: knitr
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.1.0)
 Imports:
-    Andromeda,
+    Andromeda (>= 1.0.0),
     Cyclops (>= 3.0.0),
     DatabaseConnector (>= 6.0.0),
     digest,
+    dbplyr (>= 2.4.0),
     dplyr,
-    FeatureExtraction (>= 3.0.0),
+    FeatureExtraction (>= 3.7.0),
     Matrix,
     memuse,
-    ParallelLogger (>= 2.0.0),
+    ParallelLogger (>= 2.0.2),
     pROC,
     PRROC,
     rlang,
-    SqlRender (>= 1.1.3),
+    SqlRender (>= 1.18.0),
     tidyr,
     utils
 Suggests:
@@ -47,7 +48,7 @@ Suggests:
     gridExtra,
     IterativeHardThresholding,
     knitr,
-    lightgbm,
+    lightgbm (>= 4.2.0),
     Metrics,
     mgcv,
     OhdsiShinyAppBuilder (>= 1.0.0),

--- a/R/AndromedaHelperFunctions.R
+++ b/R/AndromedaHelperFunctions.R
@@ -29,86 +29,14 @@ limitCovariatesToPopulation <- function(covariateData, rowIds) {
   }
 
   covariateData$pop <- data.frame(rowId = rowIds)
-  if (inherits(covariateData, "RSQLiteConnection")) {
-    Andromeda::createIndex(
-      tbl = covariateData$pop, columnNames = "rowId",
-      indexName = "pop_rowIds"
-    )
-  }
-
   on.exit(covariateData$pop <- NULL, add = TRUE)
 
   newCovariateData$covariates <- covariateData$covariates %>%
     dplyr::inner_join(covariateData$pop, by = "rowId")
-  if (inherits(newCovariateData, "RSQLiteConnection")) {
-    Andromeda::createIndex(
-      tbl = newCovariateData$covariates, columnNames = "covariateId",
-      indexName = "covariates_ncovariateIds"
-    )
-  }
 
   metaData$populationSize <- length(rowIds)
   attr(newCovariateData, "metaData") <- metaData
   class(newCovariateData) <- "CovariateData"
   ParallelLogger::logTrace(paste0("Finished limiting covariate data to population..."))
-  return(newCovariateData)
-}
-
-
-
-batchRestrict <- function(covariateData, population, sizeN = 10000000) {
-  ParallelLogger::logInfo("Due to data size using batchRestrict to limit covariate data to population")
-
-  start <- Sys.time()
-
-  metaData <- attr(covariateData, "metaData")
-
-  newCovariateData <- Andromeda::andromeda(
-    covariateRef = covariateData$covariateRef,
-    analysisRef = covariateData$analysisRef
-  )
-
-  if (!is.null(covariateData$timeRef)) {
-    newCovariateData$timeRef <- covariateData$timeRef
-  }
-
-  Andromeda::batchApply(covariateData$covariates, function(tempData) {
-    filtered <- dplyr::inner_join(tempData, population, by = "rowId")
-
-    if ("covariates" %in% names(newCovariateData)) {
-      Andromeda::appendToTable(newCovariateData$covariates, data = filtered)
-    } else {
-      newCovariateData$covariates <- filtered
-    }
-  },
-  progressBar = TRUE,
-  batchSize = sizeN
-  )
-
-  if (inherits(newCovariateData, "RSQLiteConnection")) {
-    Andromeda::createIndex(
-      tbl = newCovariateData$covariates,
-      columnNames = "covariateId",
-      indexName = "covariates_ncovariateIds"
-    )
-    Andromeda::createIndex(
-      tbl = newCovariateData$covariates,
-      columnNames = "rowId",
-      indexName = "covariates_rowId"
-    )
-    Andromeda::createIndex(
-      tbl = newCovariateData$covariates,
-      columnNames = c("covariateId", "covariateValue"),
-      indexName = "covariates_covariateId_value"
-    )
-  }
-
-  metaData$populationSize <- nrow(population)
-  attr(newCovariateData, "metaData") <- metaData
-  class(newCovariateData) <- "CovariateData"
-
-  timeTaken <- as.numeric(Sys.time() - start, units = "mins")
-  ParallelLogger::logInfo(paste0("Limiting covariate data took: ", timeTaken, " mins"))
-
   return(newCovariateData)
 }

--- a/R/CovariateSummary.R
+++ b/R/CovariateSummary.R
@@ -382,19 +382,10 @@ covariateSummarySubset <- function(
 
 getCovariatesForGroup <- function(covariateData, restrictIds) {
   # restrict covariateData to specified rowIds
-  if (inherits(covariateData, "RSQLiteConnection") &&
-    length(restrictIds) > 200000) {
-    newCovariateData <- batchRestrict(
-      covariateData,
-      data.frame(rowId = restrictIds),
-      sizeN = 10000000
-    )
-  } else {
-    newCovariateData <- Andromeda::copyAndromeda(covariateData)
-    covariateData$restrictIds <- data.frame(rowId = restrictIds)
-    on.exit(covariateData$restrictIds <- NULL)
-    newCovariateData$covariates <- covariateData$covariates %>%
-      dplyr::inner_join(covariateData$restrictIds, by = "rowId")
-  }
+  newCovariateData <- Andromeda::copyAndromeda(covariateData)
+  covariateData$restrictIds <- data.frame(rowId = restrictIds)
+  on.exit(covariateData$restrictIds <- NULL)
+  newCovariateData$covariates <- covariateData$covariates %>%
+    dplyr::inner_join(covariateData$restrictIds, by = "rowId")
   return(newCovariateData)
 }

--- a/R/DataSplitting.R
+++ b/R/DataSplitting.R
@@ -188,19 +188,10 @@ splitData <- function(plpData = plpData,
     trainData$folds <- trainId
 
     # restrict to trainIds
-    if (inherits(plpData$covariateData, "RSQLiteConnection") &&
-    length(trainId$rowID) > 200000) {
-      trainData$covariateData <- batchRestrict(
-        plpData$covariateData,
-        data.frame(rowId = trainId$rowId),
-        sizeN = 10000000
-      )
-    } else {
-      trainData$covariateData <- limitCovariatesToPopulation(
-        plpData$covariateData,
-        trainId$rowId
-      )
-    }
+    trainData$covariateData <- limitCovariatesToPopulation(
+      plpData$covariateData,
+      trainId$rowId
+    )
 
     metaData <- attr(population, "metaData")
     attr(trainData, "metaData") <- list(
@@ -231,19 +222,10 @@ splitData <- function(plpData = plpData,
     trainData$folds <- trainId
 
     # restrict to trainIds
-    if (inherits(plpData$covariateData, "RSQLiteConnection") &&
-    length(trainId$rowID) > 200000) {
-      trainData$covariateData <- batchRestrict(
-        plpData$covariateData,
-        data.frame(rowId = trainId$rowId),
-        sizeN = 10000000
-      )
-    } else {
-      trainData$covariateData <- limitCovariatesToPopulation(
-        plpData$covariateData,
-        trainId$rowId
-      )
-    }
+    trainData$covariateData <- limitCovariatesToPopulation(
+      plpData$covariateData,
+      trainId$rowId
+    )
     metaData <- attr(population, "metaData")
     attr(trainData, "metaData") <- list(
       outcomeId = metaData$outcomeId,
@@ -265,19 +247,10 @@ splitData <- function(plpData = plpData,
     testData$labels <- population %>%
       dplyr::filter(.data$rowId %in% testId$rowId)
 
-    if (inherits(plpData$covariateData, "RSQLiteConnection") &&
-    length(testId$rowID) > 200000) {
-      testData$covariateData <- batchRestrict(
-        plpData$covariateData,
-        data.frame(rowId = testId$rowId),
-        sizeN = 10000000
-      )
-    } else {
-      testData$covariateData <- limitCovariatesToPopulation(
-        plpData$covariateData,
-        testId$rowId
-      )
-    }
+    testData$covariateData <- limitCovariatesToPopulation(
+      plpData$covariateData,
+      testId$rowId
+    )
 
     result <- list(
       Train = trainData,
@@ -633,4 +606,3 @@ checkOutcomes <- function(population, train, nfold) {
   }
   return(invisible(TRUE))
 }
-

--- a/R/ExtractData.R
+++ b/R/ExtractData.R
@@ -408,19 +408,6 @@ getPlpData <- function(
     rowIdField = "row_id",
     covariateSettings = covariateSettings
   )
-  if (inherits(covariateData, "RSQLiteConnection")) {
-    # add indexes for tidyCov + covariate summary
-    Andromeda::createIndex(covariateData$covariates, c("rowId"),
-      indexName = "covariates_rowId"
-    )
-    Andromeda::createIndex(covariateData$covariates, c("covariateId"),
-      indexName = "covariates_covariateId"
-    )
-    Andromeda::createIndex(covariateData$covariates, c("covariateId", "covariateValue"),
-      indexName = "covariates_covariateId_value"
-    )
-  }
-
   if (max(databaseDetails$outcomeIds) != -999) {
     ParallelLogger::logTrace("Fetching outcomes from server")
     start <- Sys.time()

--- a/R/FeatureEngineering.R
+++ b/R/FeatureEngineering.R
@@ -643,10 +643,9 @@ minMaxNormalize <- function(trainData, featureEngineeringSettings, done = FALSE)
     # apply the normalization to trainData
     outData$covariateData$covariates <- outData$covariateData$covariates %>%
       dplyr::left_join(outData$covariateData$minMaxs, by = "covariateId") %>%
-      # use ifelse to only normalize if min and max are not NA as is the case
-      # for continous features, else return original value
-      dplyr::mutate(covariateValue = ifelse(!is.na(min) & !is.na(max),
-        (.data$covariateValue - min) / (max - min),
+      # Only continuous features have min/max rows after the join.
+      dplyr::mutate(covariateValue = dplyr::coalesce(
+        (.data$covariateValue - .data$min) / (.data$max - .data$min),
         .data$covariateValue
       )) %>%
       dplyr::select(-c("max", "min"))
@@ -669,8 +668,8 @@ minMaxNormalize <- function(trainData, featureEngineeringSettings, done = FALSE)
     outData$covariateData$covariates <- outData$covariateData$covariates %>%
       dplyr::left_join(outData$covariateData$minMaxs,
         by = "covariateId") %>%
-      dplyr::mutate(covariateValue = ifelse(!is.na(min) & !is.na(max),
-        (.data$covariateValue - min) / (max - min),
+      dplyr::mutate(covariateValue = dplyr::coalesce(
+        (.data$covariateValue - .data$min) / (.data$max - .data$min),
         .data$covariateValue
       )) %>%
       dplyr::select(-c("max", "min"))
@@ -728,15 +727,14 @@ robustNormalize <- function(trainData, featureEngineeringSettings, done = FALSE)
       dplyr::pull(.data$covariateId)
 
     # get (25, 75)% quantiles of each feature
-    if (inherits(outData$covariateData, "SQLiteConnection")) {
-      RSQLite::initExtension(outData$covariateData, "math")
+    if (inherits(outData$covariateData$covariates, "tbl_sql")) {
       outData$covariateData$quantiles <- outData$covariateData$covariates %>%
         dplyr::filter(.data$covariateId %in% continousFeatures) %>%
         dplyr::group_by(.data$covariateId) %>%
         dplyr::summarise(
-          q25 = dplyr::sql("lower_quartile(covariateValue)"), 
-          q75 = dplyr::sql("upper_quartile(covariateValue)"),
-          median = stats::median(.data$covariateValue, na.rm = TRUE)
+          q25 = dbplyr::sql("quantile_cont(covariateValue, 0.25)"),
+          q75 = dbplyr::sql("quantile_cont(covariateValue, 0.75)"),
+          median = dbplyr::sql("median(covariateValue)")
         ) %>%
         dplyr::mutate(iqr = .data$q75 - .data$q25) %>%
         dplyr::mutate(
@@ -765,25 +763,28 @@ robustNormalize <- function(trainData, featureEngineeringSettings, done = FALSE)
     # save the normalization
     attr(featureEngineeringSettings, "quantiles") <-
       outData$covariateData$quantiles %>% dplyr::collect()
+    clip <- featureEngineeringSettings$settings$clip
 
     # apply the normalization to trainData
     outData$covariateData$covariates <- outData$covariateData$covariates %>%
       dplyr::left_join(outData$covariateData$quantiles, by = "covariateId") %>%
-      # use ifelse to only normalize continous features
-      dplyr::mutate(covariateValue = ifelse(
-        !is.na(.data$iqr) && !is.na(.data$median),
+      dplyr::mutate(normalizeCovariate = dplyr::coalesce(
+        (.data$iqr == .data$iqr) & (.data$median == .data$median),
+        FALSE
+      )) %>%
+      # Only continuous features have median/iqr rows after the join.
+      dplyr::mutate(covariateValue = dplyr::coalesce(
         (.data$covariateValue - .data$median) / .data$iqr,
         .data$covariateValue
       )) %>%
       # optionally if settings$clip is TRUE.
       # smoothly clip the range to [-3, 3] with  x / sqrt(1 + (x/3)^2)
       # ref: https://arxiv.org/abs/2407.04491
-      dplyr::mutate(covariateValue = ifelse(!is.na(.data$iqr) &&
-        !is.na(.data$median) && featureEngineeringSettings$settings$clip,
+      dplyr::mutate(covariateValue = ifelse(.data$normalizeCovariate & !!clip,
         .data$covariateValue / sqrt(1 + (.data$covariateValue / 3)^2),
         .data$covariateValue
       )) %>%
-      dplyr::select(-c("median", "iqr"))
+      dplyr::select(-c("median", "iqr", "normalizeCovariate"))
     done <- TRUE
   } else {
     ParallelLogger::logInfo("Applying robust normalization of continuous features to test data")
@@ -799,21 +800,24 @@ robustNormalize <- function(trainData, featureEngineeringSettings, done = FALSE)
     # apply the normalization to test data by using saved normalization values
     outData$covariateData$quantiles <- attr(featureEngineeringSettings, "quantiles")
     on.exit(outData$covariateData$quantiles <- NULL, add = TRUE)
+    clip <- featureEngineeringSettings$settings$clip
     outData$covariateData$covariates <- outData$covariateData$covariates %>%
       dplyr::left_join(outData$covariateData$quantiles,
         by = "covariateId", copy = TRUE
       ) %>%
-      dplyr::mutate(covariateValue = ifelse(!is.na(.data$iqr) && !is.na(.data$median),
+      dplyr::mutate(normalizeCovariate = dplyr::coalesce(
+        (.data$iqr == .data$iqr) & (.data$median == .data$median),
+        FALSE
+      )) %>%
+      dplyr::mutate(covariateValue = dplyr::coalesce(
         (.data$covariateValue - .data$median) / .data$iqr,
         .data$covariateValue
       )) %>%
-      dplyr::mutate(covariateValue = ifelse(!is.na(.data$iqr) && 
-        !is.na(.data$median) &&
-        featureEngineeringSettings$settings$clip,
+      dplyr::mutate(covariateValue = ifelse(.data$normalizeCovariate & !!clip,
         .data$covariateValue / sqrt(1 + (.data$covariateValue / 3)^2),
         .data$covariateValue
       )) %>%
-      dplyr::select(-c("median", "iqr"))
+      dplyr::select(-c("median", "iqr", "normalizeCovariate"))
   }
   featureEngineering <- list(
     funct = "robustNormalize",

--- a/R/HelperFunctions.R
+++ b/R/HelperFunctions.R
@@ -23,6 +23,17 @@ removeInvalidString <- function(string) {
   return(modString)
 }
 
+#' Null-default operator
+#' @keywords internal
+#' @noRd
+`%||%` <- function(x, y) {
+  if (is.null(x)) {
+    y
+  } else {
+    x
+  }
+}
+
 #' Check if the required packages for survival analysis are installed
 #' @keywords internal
 #' @noRd

--- a/R/Imputation.R
+++ b/R/Imputation.R
@@ -608,10 +608,11 @@ addMissingIndicators <- function(outputData,
       featureEngineeringSettings = featureEngineeringSettings
     ))
   }
+  missingThreshold <- featureEngineeringSettings$missingThreshold
 
   if (!done) {
     sourceCovariateIds <- outputData$covariateData$missingInfo %>%
-      dplyr::filter(.data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(.data$missing <= !!missingThreshold) %>%
       dplyr::pull(.data$covariateId) %>%
       unique()
     indicatorInfo <- createMissingIndicatorInfo(outputData, sourceCovariateIds)
@@ -848,11 +849,11 @@ simpleImpute <- function(trainData, featureEngineeringSettings, done = FALSE) {
     outputData$covariateData$missingInfo <- missingInfo$missingInfo
     continuousFeatures <- missingInfo$continuousFeatures
     on.exit(outputData$covariateData$missingInfo <- NULL, add = TRUE)
+    missingThreshold <- featureEngineeringSettings$missingThreshold
 
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
-      dplyr::filter(is.na(.data$missing) |
-        .data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE)) %>%
       dplyr::select(-"missing")
     missingIndicatorResults <- addMissingIndicators(outputData, featureEngineeringSettings, done = FALSE)
     outputData <- missingIndicatorResults$outputData
@@ -916,10 +917,10 @@ simpleImpute <- function(trainData, featureEngineeringSettings, done = FALSE) {
       "missingInfo"
     )
     on.exit(outputData$covariateData$missingInfo <- NULL, add = TRUE)
+    missingThreshold <- featureEngineeringSettings$missingThreshold
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
-      dplyr::filter(is.na(.data$missing) ||
-        .data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE)) %>%
       dplyr::select(-"missing")
     missingIndicatorResults <- addMissingIndicators(outputData, featureEngineeringSettings, done = TRUE)
     outputData <- missingIndicatorResults$outputData
@@ -1001,11 +1002,11 @@ iterativeImpute <- function(trainData, featureEngineeringSettings, done = FALSE)
     outputData$covariateData$missingInfo <- missingInfo$missingInfo
     continuousFeatures <- missingInfo$continuousFeatures
     on.exit(outputData$covariateData$missingInfo <- NULL, add = TRUE)
+    missingThreshold <- featureEngineeringSettings$missingThreshold
 
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
-      dplyr::filter(is.na(.data$missing) ||
-        .data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE)) %>%
       dplyr::select(-"missing")
     missingIndicatorResults <- addMissingIndicators(outputData, featureEngineeringSettings, done = FALSE)
     outputData <- missingIndicatorResults$outputData
@@ -1080,12 +1081,12 @@ iterativeImpute <- function(trainData, featureEngineeringSettings, done = FALSE)
       "missingInfo"
     )
     on.exit(outputData$covariateData$missingInfo <- NULL, add = TRUE)
+    missingThreshold <- featureEngineeringSettings$missingThreshold
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
       # Keep test-path covariates with the same missing-threshold rule as training.
       # This preserves non-imputed feature parity between train and test.
-      dplyr::filter(is.na(.data$missing) ||
-        .data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE)) %>%
       dplyr::select(-"missing")
     missingIndicatorResults <- addMissingIndicators(outputData, featureEngineeringSettings, done = TRUE)
     outputData <- missingIndicatorResults$outputData
@@ -1267,13 +1268,11 @@ sklearnIterativeImpute <- function(trainData, featureEngineeringSettings, done =
     missingInfo <- extractMissingInfo(outputData)
     outputData$covariateData$missingInfo <- missingInfo$missingInfo
     on.exit(outputData$covariateData$missingInfo <- NULL, add = TRUE)
+    missingThreshold <- featureEngineeringSettings$missingThreshold
 
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
-      dplyr::filter(
-        is.na(.data$missing) ||
-          .data$missing <= featureEngineeringSettings$missingThreshold
-      ) %>%
+      dplyr::filter(dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE)) %>%
       dplyr::select(-"missing")
 
     missingIndicatorResults <- addMissingIndicators(outputData, featureEngineeringSettings, done = FALSE)
@@ -1285,7 +1284,7 @@ sklearnIterativeImpute <- function(trainData, featureEngineeringSettings, done =
       unique() %>%
       sort()
     targetCovariateIds <- outputData$covariateData$missingInfo %>%
-      dplyr::filter(.data$missing <= featureEngineeringSettings$missingThreshold) %>%
+      dplyr::filter(.data$missing <= !!missingThreshold) %>%
       dplyr::pull(.data$covariateId) %>%
       unique()
     targetCovariateIds <- targetCovariateIds[targetCovariateIds %in% predictorCovariateIds]
@@ -1387,12 +1386,12 @@ sklearnIterativeImpute <- function(trainData, featureEngineeringSettings, done =
     if (is.null(targetCovariateIds)) {
       targetCovariateIds <- numeric(0)
     }
+    missingThreshold <- featureEngineeringSettings$missingThreshold
 
     outputData$covariateData$covariates <- outputData$covariateData$covariates %>%
       dplyr::left_join(outputData$covariateData$missingInfo, by = "covariateId") %>%
       dplyr::filter(
-        (is.na(.data$missing) ||
-          .data$missing <= featureEngineeringSettings$missingThreshold) &&
+        dplyr::coalesce(.data$missing <= !!missingThreshold, TRUE) &
           .data$covariateId %in% !!predictorCovariateIds
       ) %>%
       dplyr::select(-"missing")

--- a/R/Predict.R
+++ b/R/Predict.R
@@ -182,11 +182,6 @@ applyTidyCovariateData <- function(
   temp <- covariateData$covariateRef %>% dplyr::collect()
   allCovariateIds <- temp$covariateId
   covariateData$includeCovariates <- data.frame(covariateId = allCovariateIds[!allCovariateIds %in% deleteCovariateIds])
-  if (inherits(covariateData, "RSQLiteConnection")) {
-    Andromeda::createIndex(covariateData$includeCovariates, c("covariateId"),
-      indexName = "includeCovariates_covariateId"
-    )
-  }
   on.exit(covariateData$includeCovariates <- NULL, add = TRUE)
   # ---
 
@@ -203,13 +198,6 @@ applyTidyCovariateData <- function(
     }
     on.exit(covariateData$maxes <- NULL, add = TRUE)
 
-    if (inherits(covariateData, "RSQLiteConnection")) {
-      # --- added for speed
-      Andromeda::createIndex(covariateData$maxes, c("covariateId"),
-        indexName = "maxes_covariateId"
-      )
-    } # ---
-
     newCovariateData$covariates <- covariateData$covariates %>%
       dplyr::inner_join(covariateData$includeCovariates, by = "covariateId") %>% # added as join
       dplyr::inner_join(covariateData$maxes, by = "covariateId") %>%
@@ -225,15 +213,6 @@ applyTidyCovariateData <- function(
   newCovariateData$covariateRef <- covariateData$covariateRef %>%
     dplyr::inner_join(covariateData$includeCovariates, by = "covariateId")
 
-
-  if (inherits(newCovariateData, "RSQLiteConnection")) {
-    # adding index for restrict to pop
-    Andromeda::createIndex(
-      newCovariateData$covariates,
-      c("rowId"),
-      indexName = "ncovariates_rowId"
-    )
-  }
   class(newCovariateData) <- "CovariateData"
 
   delta <- Sys.time() - start

--- a/R/Simulation.R
+++ b/R/Simulation.R
@@ -895,18 +895,6 @@ resampleBenchmarkCovariateData <- function(covariateData, rowMap, populationSize
       covariateId = .data$covariateId,
       covariateValue = .data$covariateValue
     )
-  if (inherits(result, "RSQLiteConnection")) {
-    Andromeda::createIndex(
-      tbl = result$covariates,
-      columnNames = "rowId",
-      indexName = "covariates_rowId"
-    )
-    Andromeda::createIndex(
-      tbl = result$covariates,
-      columnNames = "covariateId",
-      indexName = "covariates_covariateId"
-    )
-  }
 
   class(result) <- "CovariateData"
   attr(class(result), "package") <- "FeatureExtraction"

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -13,7 +13,9 @@ if (Sys.getenv("GITHUB_ACTIONS") == "true") {
 
 if (rlang::is_installed("reticulate") && identical(Sys.getenv("NOT_CRAN"), "true")) {
   if (Sys.getenv("GITHUB_ACTIONS") == "true") {
-    reticulate::py_require("scikit-learn", python_version = Sys.getenv("RETICULATE_PY_VERSION"))
+    if (Sys.getenv("RETICULATE_PYTHON") == "") {
+      reticulate::py_require("scikit-learn", python_version = Sys.getenv("RETICULATE_PY_VERSION"))
+    }
     # force instantiation of python with correct version
     sklearn <- reticulate::import("sklearn")
   } else {

--- a/tests/testthat/test-LightGBM.R
+++ b/tests/testthat/test-LightGBM.R
@@ -130,13 +130,13 @@ test_that("LightGBM working checks", {
 
   loadedBooster <- lightgbm::lgb.load(model_str = serialized$model)
   expect_equal(class(loadedBooster), c("lgb.Booster", "R6"))
-  expect_equal(loadedBooster$num_trees(), fitModel$model$num_trees())
+  expect_equal(loadedBooster$current_iter(), fitModel$model$current_iter())
 
   loadModel <- loadPlpModel(savePath)
 
   expect_s3_class(loadModel, "plpModel")
   expect_equal(class(loadModel$model), c("lgb.Booster", "R6"))
-  expect_equal(loadModel$model$num_trees(), fitModel$model$num_trees())
+  expect_equal(loadModel$model$current_iter(), fitModel$model$current_iter())
 
   predFit <- predictPlp(
     plpModel = fitModel,

--- a/tests/testthat/test-UploadToDatabase.R
+++ b/tests/testthat/test-UploadToDatabase.R
@@ -12,18 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# only run this during CI in main repo
-if (Sys.getenv("CI") == "true" &&
-  Sys.getenv("GITHUB_REPOSITORY") == "OHDSI/PatientLevelPrediction") {
-  cdmDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_CDM_SCHEMA")
-  ohdsiDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_OHDSI_SCHEMA")
+runPostgresUploadTests <- Sys.getenv("CI") == "true" &&
+  Sys.getenv("GITHUB_REPOSITORY") == "OHDSI/PatientLevelPrediction" &&
+  all(nzchar(Sys.getenv(c(
+    "CDM5_POSTGRESQL_CDM_SCHEMA",
+    "CDM5_POSTGRESQL_OHDSI_SCHEMA",
+    "CDM5_POSTGRESQL_PASSWORD",
+    "CDM5_POSTGRESQL_SERVER",
+    "CDM5_POSTGRESQL_USER"
+  )))) &&
+  grepl("/", Sys.getenv("CDM5_POSTGRESQL_SERVER"), fixed = TRUE)
+
+skip_if_no_postgres_upload <- function() {
+  skip_if(!runPostgresUploadTests, "PostgreSQL test connection is not configured")
+}
+
+# only run this during CI in main repo when PostgreSQL secrets are available
+if (runPostgresUploadTests) {
   cdmDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_CDM_SCHEMA")
   ohdsiDatabaseSchema <- Sys.getenv("CDM5_POSTGRESQL_OHDSI_SCHEMA")
   connectionRedshift <- DatabaseConnector::createConnectionDetails(
     dbms = "postgresql",
     user = Sys.getenv("CDM5_POSTGRESQL_USER"),
     password = URLdecode(Sys.getenv("CDM5_POSTGRESQL_PASSWORD")),
-    server = Sys.getenv("CDM5_POSTGRESQL_SERVER"),
+    server = Sys.getenv("CDM5_POSTGRESQL_SERVER")
   )
   conn <- DatabaseConnector::connect(connectionRedshift)
   targetDialect <- "postgresql"
@@ -36,8 +48,7 @@ if (Sys.getenv("CI") == "true" &&
   }
 }
 test_that("test createDatabaseSchemaSettings works", {
-  skip_if(Sys.getenv("CI") != "true", "only run on CI")
-  skip_if(Sys.getenv("GITHUB_REPOSITORY") != "OHDSI/PatientLevelPrediction", "not run in fork")
+  skip_if_no_postgres_upload()
   databaseSchemaSettings <- createDatabaseSchemaSettings(
     resultSchema = ohdsiDatabaseSchema,
     tablePrefix = "",
@@ -89,8 +100,7 @@ test_that("test createDatabaseDetails works", {
 
 
 test_that("database creation", {
-  skip_if(Sys.getenv("CI") != "true", "only run on CI")
-  skip_if(Sys.getenv("GITHUB_REPOSITORY") != "OHDSI/PatientLevelPrediction", "not run in fork")
+  skip_if_no_postgres_upload()
   createPlpResultTables(
     connectionDetails = connectionRedshift,
     resultSchema = ohdsiDatabaseSchema,
@@ -110,8 +120,7 @@ test_that("database creation", {
 
 
 test_that("results uploaded to database", {
-  skip_if(Sys.getenv("CI") != "true", "only run on CI")
-  skip_if(Sys.getenv("GITHUB_REPOSITORY") != "OHDSI/PatientLevelPrediction", "not run in fork")
+  skip_if_no_postgres_upload()
   resultsLoc <- file.path(saveLoc, "dbUp")
 
   plpResult$model$trainDetails$developmentDatabase <- "test"
@@ -151,7 +160,7 @@ test_that("results uploaded to database", {
   )
 
   # check the results table is populated
-  sql <- "select count(*) as N from @resultSchema.@appendperformances;"
+  sql <- "select count(*) as n from @resultSchema.@appendperformances;"
   sql <- SqlRender::render(sql, resultSchema = ohdsiDatabaseSchema, append = appendRandom("test_"))
   res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
   expect_true(res$n[1] > 0)
@@ -160,8 +169,7 @@ test_that("results uploaded to database", {
 })
 
 test_that("database deletion", {
-  skip_if(Sys.getenv("CI") != "true", "only run on CI")
-  skip_if(Sys.getenv("GITHUB_REPOSITORY") != "OHDSI/PatientLevelPrediction", "not run in fork")
+  skip_if_no_postgres_upload()
   createPlpResultTables(
     connectionDetails = connectionRedshift,
     resultSchema = ohdsiDatabaseSchema,
@@ -192,7 +200,7 @@ test_that("database deletion", {
 })
 
 # disconnect
-if (Sys.getenv("CI") == "true" && Sys.getenv("GITHUB_REPOSITORY") == "OHDSI/PatientLevelPrediction") {
+if (runPostgresUploadTests) {
   DatabaseConnector::disconnect(conn)
 }
 
@@ -233,25 +241,25 @@ test_that("temporary sqlite with results works", {
   targetDialect <- "sqlite"
 
   # check the results table is populated
-  sql <- "select count(*) as N from main.performances;"
-  res <- DatabaseConnector::querySql(conn, sql)
-  expect_true(res$N[1] > 0)
+  sql <- "select count(*) as n from main.performances;"
+  res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
+  expect_true(res$n[1] > 0)
 
   # check the diagnostic table is populated
-  sql <- "select count(*) as N from main.diagnostics;"
-  res <- DatabaseConnector::querySql(conn, sql)
-  expect_true(res$N[1] > 0)
+  sql <- "select count(*) as n from main.diagnostics;"
+  res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
+  expect_true(res$n[1] > 0)
 
   # check the models table is populated and intercept is stored correctly
   sql <- paste(
     "select",
-    "  model_type as modelType,",
+    "  model_type as model_type,",
     "  intercept as intercept,",
-    "  plp_model_file as plpModelFile,",
-    "  train_details as trainDetails",
+    "  plp_model_file as plp_model_file,",
+    "  train_details as train_details",
     "from main.models;"
   )
-  res <- DatabaseConnector::querySql(conn, sql)
+  res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
   expect_true(nrow(res) > 0)
   expect_true(all(!is.na(res$plpModelFile)))
   expect_true(dir.exists(res$plpModelFile[1]))
@@ -320,7 +328,11 @@ test_that("list hyperParamSearch is flattened for sqlite uploads", {
   conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
   on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
 
-  res <- DatabaseConnector::querySql(conn, "select train_details as trainDetails from main.models;")
+  res <- DatabaseConnector::querySql(
+    conn,
+    "select train_details as train_details from main.models;",
+    snakeCaseToCamelCase = TRUE
+  )
   expect_true(nrow(res) > 0)
   trainDetails <- ParallelLogger::convertJsonToSettings(res$trainDetails[1])
 
@@ -414,7 +426,11 @@ test_that("insertModelDesignInDatabase handles missing hyperparameterSettings in
   expect_false(is.null(modelDesignId))
   expect_true(is.numeric(modelDesignId) || is.integer(modelDesignId))
 
-  countRes <- DatabaseConnector::querySql(conn, "select count(*) as n from main.model_designs;")
+  countRes <- DatabaseConnector::querySql(
+    conn,
+    "select count(*) as n from main.model_designs;",
+    snakeCaseToCamelCase = TRUE
+  )
   expect_true(countRes$n[1] > 0)
 })
 
@@ -452,13 +468,13 @@ test_that("temporary sqlite with results works", {
   targetDialect <- "sqlite"
 
   # check the results table is populated
-  sql <- "select count(*) as N from main.performances;"
-  res <- DatabaseConnector::querySql(conn, sql)
-  expect_true(res$N[1] > 0)
+  sql <- "select count(*) as n from main.performances;"
+  res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
+  expect_true(res$n[1] > 0)
 
   # models table exists and has expected intercept
-  sql <- "select intercept as intercept, plp_model_file as plpModelFile from main.models;"
-  res <- DatabaseConnector::querySql(conn, sql)
+  sql <- "select intercept as intercept, plp_model_file as plp_model_file from main.models;"
+  res <- DatabaseConnector::querySql(conn, sql, snakeCaseToCamelCase = TRUE)
   expect_true(nrow(res) > 0)
   expect_true(dir.exists(res$plpModelFile[1]))
   expect_equal(
@@ -515,8 +531,12 @@ test_that("external validation with no outcomes uploads to sqlite", {
   conn <- DatabaseConnector::connect(connectionDetails = connectionDetails)
   on.exit(DatabaseConnector::disconnect(conn), add = TRUE)
 
-  res <- DatabaseConnector::querySql(conn, "select count(*) as N from main.performances;")
-  expect_gte(res$N[1], 2)
+  res <- DatabaseConnector::querySql(
+    conn,
+    "select count(*) as n from main.performances;",
+    snakeCaseToCamelCase = TRUE
+  )
+  expect_gte(res$n[1], 2)
 
   expect_true(DatabaseConnector::existsTable(
     connection = conn,
@@ -524,16 +544,21 @@ test_that("external validation with no outcomes uploads to sqlite", {
     tableName = "evaluation_statistics"
   ))
 
-  perf <- DatabaseConnector::querySql(conn, "select max(performance_id) as performanceId from main.performances;")
+  perf <- DatabaseConnector::querySql(
+    conn,
+    "select max(performance_id) as performance_id from main.performances;",
+    snakeCaseToCamelCase = TRUE
+  )
   evalRows <- DatabaseConnector::querySql(
     conn,
     paste0(
-      "select count(*) as N from main.evaluation_statistics where performance_id = ",
+      "select count(*) as n from main.evaluation_statistics where performance_id = ",
       perf$performanceId[1],
       ";"
-    )
+    ),
+    snakeCaseToCamelCase = TRUE
   )
-  expect_gt(evalRows$N[1], 0)
+  expect_gt(evalRows$n[1], 0)
 })
 
 # importFromCsv test here as can use previous csv saving

--- a/tests/testthat/test-UploadToDatabaseModelDesign.R
+++ b/tests/testthat/test-UploadToDatabaseModelDesign.R
@@ -38,7 +38,8 @@ test_that("addModelSetting handles minimal modelSettings objects", {
 
   res <- DatabaseConnector::querySql(
     conn,
-    "select model_type as modelType, model_name as modelName from main.model_settings;"
+    "select model_type as model_type, model_name as model_name from main.model_settings;",
+    snakeCaseToCamelCase = TRUE
   )
   expect_true("modelType" %in% names(res))
   expect_true("modelName" %in% names(res))
@@ -125,10 +126,11 @@ test_that("addModelSetting derives modelType/modelName and sanitizes invalid val
     res <- DatabaseConnector::querySql(
       conn,
       paste0(
-        "select model_type as modelType, model_name as modelName ",
+        "select model_type as model_type, model_name as model_name ",
         "from main.model_settings ",
         "where model_setting_id = ", modelSettingId, ";"
-      )
+      ),
+      snakeCaseToCamelCase = TRUE
     )
     expect_equal(res$modelType[1], expectedModelTypes[i])
     expect_equal(res$modelName[1], expectedModelNames[i])
@@ -187,12 +189,17 @@ test_that("Migration_3 adds model_name and backfills from models table", {
   )
   DatabaseConnector::executeSql(conn, migrationSql)
 
-  columnInfo <- DatabaseConnector::querySql(conn, "PRAGMA table_info(model_settings);")
+  columnInfo <- DatabaseConnector::querySql(
+    conn,
+    "PRAGMA table_info(model_settings);",
+    snakeCaseToCamelCase = TRUE
+  )
   expect_true("model_name" %in% columnInfo$name)
 
   migrated <- DatabaseConnector::querySql(
     conn,
-    "select model_name as modelName from main.model_settings where model_setting_id = 1;"
+    "select model_name as model_name from main.model_settings where model_setting_id = 1;",
+    snakeCaseToCamelCase = TRUE
   )
   expect_equal(migrated$modelName[1], "xgboost")
 })
@@ -227,7 +234,8 @@ test_that("addHyperparameterSetting deduplicates identical settings json", {
 
   rowCountBefore <- DatabaseConnector::querySql(
     conn,
-    "select count(*) as n from main.hyperparameter_settings;"
+    "select count(*) as n from main.hyperparameter_settings;",
+    snakeCaseToCamelCase = TRUE
   )
 
   firstId <- PatientLevelPrediction:::addHyperparameterSetting(
@@ -251,7 +259,8 @@ test_that("addHyperparameterSetting deduplicates identical settings json", {
 
   rowCountAfter <- DatabaseConnector::querySql(
     conn,
-    "select count(*) as n from main.hyperparameter_settings;"
+    "select count(*) as n from main.hyperparameter_settings;",
+    snakeCaseToCamelCase = TRUE
   )
   expect_equal(rowCountAfter$n[1], rowCountBefore$n[1] + 1)
 })
@@ -338,17 +347,19 @@ test_that("insertModelDesignInDatabase differentiates model_design_id by hyperpa
   modelDesignRows <- DatabaseConnector::querySql(
     conn,
     paste0(
-      "select model_design_id as modelDesignId, ",
-      "hyperparameter_setting_id as hyperparameterSettingId ",
+      "select model_design_id as model_design_id, ",
+      "hyperparameter_setting_id as hyperparameter_setting_id ",
       "from main.model_designs where model_design_id in (",
       modelDesignGridId, ", ", modelDesignRandomId, ");"
-    )
+    ),
+    snakeCaseToCamelCase = TRUE
   )
   expect_equal(length(unique(modelDesignRows$hyperparameterSettingId)), 2)
 
   hyperparameterRows <- DatabaseConnector::querySql(
     conn,
-    "select count(*) as n from main.hyperparameter_settings;"
+    "select count(*) as n from main.hyperparameter_settings;",
+    snakeCaseToCamelCase = TRUE
   )
   expect_gte(hyperparameterRows$n[1], 2)
 })

--- a/tests/testthat/test-andromedahelperfunctions.R
+++ b/tests/testthat/test-andromedahelperfunctions.R
@@ -15,14 +15,13 @@
 # limitations under the License.
 
 # add limitCovariatesToPopulation(covariateData, rowIds) test
-test_that("batchRestrict", {
+test_that("limitCovariatesToPopulation preserves metadata", {
   skip_if_offline()
   metaData <- attr(plpData$covariateData, "metaData")
   covariateData <-
-    PatientLevelPrediction:::batchRestrict(
+    PatientLevelPrediction:::limitCovariatesToPopulation(
       plpData$covariateData,
-      population,
-      sizeN = 1000000
+      population$rowId
     )
   expect_s4_class(covariateData, "CovariateData")
 

--- a/tests/testthat/test-helperfunctions.R
+++ b/tests/testthat/test-helperfunctions.R
@@ -26,6 +26,12 @@ test_that("listAppend", {
   expect_equal(length(listAppend(list1, list2)), 3)
 })
 
+test_that("null-default operator uses right-hand side only for NULL", {
+  expect_equal(NULL %||% "fallback", "fallback")
+  expect_equal(FALSE %||% "fallback", FALSE)
+  expect_equal(0 %||% "fallback", 0)
+})
+
 # how to test configurePython?
 
 test_that("setPythonEnvironment", {

--- a/tests/testthat/test-normalizers.R
+++ b/tests/testthat/test-normalizers.R
@@ -34,7 +34,6 @@ test_that("createNormalizer works", {
 })
 
 test_that("normalization works", {
-  skip_if_not_installed("RSQLite") # until Andromeda 1.0.0 is released
   addFeature <- function(data, covariateId, minValue,
                          maxValue, outliers = FALSE) {
     data$covariateData <- Andromeda::copyAndromeda(data$covariateData)
@@ -114,15 +113,9 @@ test_that("normalization works", {
         trainMedian <- median(data$covariateData$covariates %>%
           dplyr::filter(.data$covariateId == 12101) %>%
           dplyr::pull(.data$covariateValue))
-        if (inherits(data$covariateData, "SQLiteConnection")) {
-          trainIQR <- IQR(data$covariateData$covariates %>%
-            dplyr::filter(.data$covariateId == 12101) %>%
-            dplyr::pull(.data$covariateValue), type = 1)
-        } else {
-          trainIQR <- IQR(data$covariateData$covariates %>%
-            dplyr::filter(.data$covariateId == 12101) %>%
-            dplyr::pull(.data$covariateValue))
-        }
+        trainIQR <- IQR(data$covariateData$covariates %>%
+          dplyr::filter(.data$covariateId == 12101) %>%
+          dplyr::pull(.data$covariateValue))
         testNormFeature <- (testFeature - trainMedian) / trainIQR
         if (clip) {
           testNormFeature <- testNormFeature / sqrt(1 + (testNormFeature / 3)^2)


### PR DESCRIPTION
## Summary
- raise dependency floors needed for old-R-compatible installs and add an internal `%||%` fallback
- make imputation and normalizer SQL generation work with the dependency floor stack
- require DuckDB-backed Andromeda (`>= 1.0.0`) and remove SQLite-backed Andromeda special cases
- add a manual dependency-floor GitHub Actions workflow

## Testing
- `Rscript -e 'testthat::test_local("tests/testthat", filter = "andromedahelperfunctions|normalizers|preprocessingData|simulation", reporter = "summary")'`\n- `R CMD build --no-build-vignettes --no-manual .`\n- `R CMD check --no-manual --no-build-vignettes --ignore-vignettes --no-tests --no-examples PatientLevelPrediction_*.tar.gz`