### PR TITLE
fix: accept lifecycle hyperparameter generators

### DIFF
--- a/R/HyperparameterSettings.R
+++ b/R/HyperparameterSettings.R
@@ -4,8 +4,12 @@
 #'   choices include `aucMetric` and `auprcMetric`.
 #' @param sampleSize Sample size in case of random sampling
 #' @param randomSeed Random seed for random sampling
-#' @param generator An object with `initialize`, `getNext` and `finalize` methods 
-#' for custom flexible hyperparameter tuning.
+#' @param generator Optional custom hyperparameter generator. This can be either
+#' a function with arguments `definition`, `expanded`, and `settings` that
+#' returns a finite list of named parameter lists, or an object with lifecycle
+#' methods. Lifecycle generator objects must provide `initialize(definition,
+#' settings)` and `getNext(history)` methods, and may provide an optional
+#' `finalize(history)` method.
 #' @export
 createHyperparameterSettings <- function(
   search = "grid",
@@ -19,7 +23,12 @@ createHyperparameterSettings <- function(
     stopifnot(length(sampleSize) == 1, is.numeric(sampleSize))
   }
   if (!is.null(generator)) {
-    stopifnot(is.function(generator))
+    if (!isHyperparameterGenerator(generator)) {
+      stop(
+        "`generator` must be a function or an object with initialize and getNext methods; finalize is optional.",
+        call. = FALSE
+      )
+    }
     search <- "custom"
   }
 
@@ -33,6 +42,24 @@ createHyperparameterSettings <- function(
     ),
     class = "hyperparameterSettings"
   )
+}
+
+isHyperparameterGenerator <- function(generator) {
+  if (is.function(generator)) {
+    return(TRUE)
+  }
+
+  getMember <- function(name) {
+    tryCatch(generator[[name]], error = function(e) NULL)
+  }
+
+  initialize <- getMember("initialize")
+  getNext <- getMember("getNext")
+  finalize <- getMember("finalize")
+
+  is.function(initialize) &&
+    is.function(getNext) &&
+    (is.null(finalize) || is.function(finalize))
 }
 
 

--- a/man/createHyperparameterSettings.Rd
+++ b/man/createHyperparameterSettings.Rd
@@ -22,8 +22,12 @@ choices include \code{aucMetric} and \code{auprcMetric}.}
 
 \item{randomSeed}{Random seed for random sampling}
 
-\item{generator}{An object with \code{initialize}, \code{getNext} and \code{finalize} methods
-for custom flexible hyperparameter tuning.}
+\item{generator}{Optional custom hyperparameter generator. This can be either
+a function with arguments \code{definition}, \code{expanded}, and \code{settings} that
+returns a finite list of named parameter lists, or an object with lifecycle
+methods. Lifecycle generator objects must provide \code{initialize(definition,
+settings)} and \code{getNext(history)} methods, and may provide an optional
+\code{finalize(history)} method.}
 }
 \description{
 Create Hyperparameter Settings

--- a/tests/testthat/test-hyperparameterSettings.R
+++ b/tests/testthat/test-hyperparameterSettings.R
@@ -70,6 +70,40 @@ test_that("createHyperparameterSettings accepts generator objects with lifecycle
   expect_identical(settings$generator, generator)
 })
 
+test_that("createHyperparameterSettings accepts generator objects without finalize", {
+  generator <- list(
+    initialize = function(definition, settings) invisible(NULL),
+    getNext = function(history) NULL
+  )
+
+  settings <- createHyperparameterSettings(generator = generator)
+
+  expect_equal(settings$search, "custom")
+  expect_identical(settings$generator, generator)
+})
+
+test_that("createHyperparameterSettings rejects invalid generator objects", {
+  expect_error(
+    createHyperparameterSettings(generator = list(getNext = function(history) NULL)),
+    "`generator` must be a function or an object with initialize and getNext methods",
+    fixed = TRUE
+  )
+  expect_error(
+    createHyperparameterSettings(generator = list(
+      initialize = function(definition, settings) invisible(NULL),
+      getNext = function(history) NULL,
+      finalize = "not a function"
+    )),
+    "`generator` must be a function or an object with initialize and getNext methods",
+    fixed = TRUE
+  )
+  expect_error(
+    createHyperparameterSettings(generator = 1),
+    "`generator` must be a function or an object with initialize and getNext methods",
+    fixed = TRUE
+  )
+})
+
 test_that("prepareHyperparameterGrid returns sequential combinations for grid search", {
   paramDefinition <- list(alpha = list(0.1, 0.2), lambda = list(1L, 2L))
   iterator <- prepareHyperparameterGrid(

--- a/tests/testthat/test-hyperparameterSettings.R
+++ b/tests/testthat/test-hyperparameterSettings.R
@@ -57,6 +57,19 @@ test_that("auprcMetric wraps averagePrecision", {
   expect_equal(auprcMetric$fun(prediction), auprcFun(prediction))
 })
 
+test_that("createHyperparameterSettings accepts generator objects with lifecycle hooks", {
+  generator <- list(
+    initialize = function(definition, settings) invisible(NULL),
+    getNext = function(history) NULL,
+    finalize = function(history) invisible(NULL)
+  )
+
+  settings <- createHyperparameterSettings(generator = generator)
+
+  expect_equal(settings$search, "custom")
+  expect_identical(settings$generator, generator)
+})
+
 test_that("prepareHyperparameterGrid returns sequential combinations for grid search", {
   paramDefinition <- list(alpha = list(0.1, 0.2), lambda = list(1L, 2L))
   iterator <- prepareHyperparameterGrid(


### PR DESCRIPTION
## Summary
- allow `createHyperparameterSettings()` to accept lifecycle generator objects with `initialize()` and `getNext()`
- keep function generators supported and document both generator contracts explicitly
- add regression coverage for generator objects passed through the constructor

Fixes #665

## Testing
- `Rscript -e 'devtools::test(filter = "hyperparameterSettings")'`