### PR TITLE
fix(cyclops): apply controls to CV refits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ PatientLevelPrediction 6.6.0
 - Added outcome-limited split settings for large data sets where model training should use a target number of outcome-positive rows (#396).
 
 ## Bug fixes
+- Ensured Cyclops cross-validation refits honor configured thread, seed,
+  tolerance, and iteration settings (#672).
 - Fixed cross-validation prediction generation for iterative hard thresholding models by reusing fitted per-covariate prior variances.
 - Restored intercept fitting for iterative hard thresholding logistic models.
 - Fixed simulation profile outcome models so generated coefficients only reference covariates available in the profile, added support for user-supplied outcome models, and invalid custom profiles now fail early instead of silently dropping outcome signal.

--- a/R/CyclopsModels.R
+++ b/R/CyclopsModels.R
@@ -144,7 +144,8 @@ fitCyclopsModel <- function(
     labels = trainData$covariateData$labels,
     folds = trainData$folds,
     modelSettings = modelSettings,
-    covariateData  = trainData$covariateData
+    covariateData  = trainData$covariateData,
+    control = createCyclopsRefitControl(modelSettings)
   )
 
   if (!is.null(param$priorCoefs)) {
@@ -378,7 +379,7 @@ predictCyclopsType <- function(coefficients, population, covariateData, modelTyp
 
 
 createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, labels, folds,
-                               modelSettings, covariateData = NULL) {
+                               modelSettings, covariateData = NULL, control = NULL) {
   if (is.character(fit)) {
     coefficients <- c(0)
     names(coefficients) <- ""
@@ -442,7 +443,8 @@ createCyclopsModel <- function(fit, modelType, useCrossValidation, cyclopsData, 
       cvPrior = cvPrior,
       folds = folds,
       covariateData = covariateData,
-      modelType = modelType
+      modelType = modelType,
+      control = control
     )
   }
 
@@ -552,6 +554,19 @@ checkCyclopsCovariates <- function(cyclopsData, covariates) {
   covariates
 }
 
+createCyclopsRefitControl <- function(modelSettings) {
+  settings <- modelSettings$settings
+  priorParams <- modelSettings$param$priorParams
+  values <- list(
+    tolerance = settings$tolerance %||% priorParams$tolerance,
+    threads = settings$threads,
+    maxIterations = settings$maxIterations %||% priorParams$maxIterations,
+    seed = settings$seed
+  )
+  values <- values[!vapply(values, is.null, logical(1))]
+  do.call(Cyclops::createControl, c(list(noiseLevel = "silent"), values))
+}
+
 
 
 getCV <- function(
@@ -560,7 +575,8 @@ getCV <- function(
     cvPrior,
     folds,
     covariateData = NULL,
-    modelType = "logistic"
+    modelType = "logistic",
+    control = NULL
 ) {
   # add the index to the labels
   labels <- merge(labels, folds, by = "rowId")
@@ -571,7 +587,8 @@ getCV <- function(
     weights[hold_out] <- 0.0
     subset_fit <- suppressWarnings(Cyclops::fitCyclopsModel(cyclopsData,
       prior = cvPrior,
-      weights = weights
+      weights = weights,
+      control = control
     ))
     coefficients <- stats::coef(subset_fit)
     coefDf <- data.frame(

--- a/tests/testthat/test-cyclopsModels.R
+++ b/tests/testthat/test-cyclopsModels.R
@@ -297,6 +297,32 @@ test_that("test IHT incorrect inputs", {
   expect_error(setIterativeHardThresholding(seed = "F"))
 })
 
+test_that("Cyclops CV refit controls preserve model settings", {
+  lassoControl <- createCyclopsRefitControl(setLassoLogisticRegression(
+    seed = 42,
+    threads = 2,
+    tolerance = 1e-5,
+    maxIterations = 17
+  ))
+
+  expect_equal(lassoControl$seed, 42)
+  expect_equal(lassoControl$threads, 2)
+  expect_equal(lassoControl$tolerance, 1e-5)
+  expect_equal(lassoControl$maxIterations, 17)
+  expect_equal(lassoControl$noiseLevel, "silent")
+
+  skip_if_not_installed("IterativeHardThresholding")
+  ihtControl <- createCyclopsRefitControl(setIterativeHardThresholding(
+    seed = 43,
+    tolerance = 2e-5,
+    maxIterations = 19
+  ))
+
+  expect_equal(ihtControl$seed, 43)
+  expect_equal(ihtControl$tolerance, 2e-5)
+  expect_equal(ihtControl$maxIterations, 19)
+})
+
 
 
 # ================ FUNCTION TESTING


### PR DESCRIPTION
## Summary
- pass configured Cyclops controls to fold-level CV refits
- preserve thread, seed, tolerance, and iteration settings
- cover standard and per-covariate-prior model settings

Closes #672.

## Tests
- `devtools::test(filter = "cyclopsModels")` (155 passed)
